### PR TITLE
Fix didRegisterForRemoteNotification on iOS8

### DIFF
--- a/src/ios/AppDelegate+notification.h
+++ b/src/ios/AppDelegate+notification.h
@@ -13,8 +13,10 @@
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo;
 - (void)applicationDidBecomeActive:(UIApplication *)application;
+- (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings;
+- (void)application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo completionHandler:(void(^)())completionHandler;
 - (id) getCommandInstance:(NSString*)className;
 
-@property (nonatomic, retain) NSDictionary	*launchNotification;
+@property (nonatomic, retain) NSDictionary  *launchNotification;
 
 @end


### PR DESCRIPTION
* `didRegisterForRemoteNotificationsWithDeviceToken` is now called in iOS8 via `didRegisterUserNotificationSettings`
* fixed calls to `getCommandInstance` to use "PushNotification" instead of legacy "PushPlugin"

fixes #4 - Register method not working