### PR TITLE
add support for android icons/large-icons plus ability to override with the gcm keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Parameter | Description
 `options` | `JSON Object` platform specific initialization options.
 `options.android` | `JSON Object` Android specific initialization options.
 `options.android.senderID` | `String` Maps to the project number in the Google Developer Console.
+`options.android.icon` | `String` Optional. The name of a drawable resource to use as the small-icon. You can also override this option server-side by sending a `icon` key on the gcm data.
+`options.android.largeIcon` | `String` Optional. The name of a drawable resource to use as the large-icon. You can also override this option server-side by sending a `largeIcon` key on the gcm data.
 `options.ios` | `JSON Object` iOS specific initialization options.
 `options.windows` | `JSON Object` Windows specific initialization options.
 
@@ -104,6 +106,7 @@ Callback Parameter | Description
 `data.sound` | `String` The name of the sound file to be played upon receipt of the notification.
 `data.image (windows only)` | `String` The path of the image file to be displayed in the notification.
 `data.additionalData` | `JSON Object` An optional collection of data sent by the 3rd party push service that does not fit in the above properties.
+`data.additionalData.foreground` | `Boolean` Whether the notification was received while the app was in the foreground
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Parameter | Description
 `options.android` | `JSON Object` Android specific initialization options.
 `options.android.senderID` | `String` Maps to the project number in the Google Developer Console.
 `options.android.icon` | `String` Optional. The name of a drawable resource to use as the small-icon. You can also override this option server-side by sending a `icon` key on the gcm data.
+`options.android.iconColor` | `String` Optional. Sets the background color of the small icon. [Supported Formats](http://developer.android.com/reference/android/graphics/Color.html#parseColor(java.lang.String))
 `options.android.largeIcon` | `String` Optional. The name of a drawable resource to use as the large-icon. You can also override this option server-side by sending a `largeIcon` key on the gcm data.
 `options.ios` | `JSON Object` iOS specific initialization options.
 `options.windows` | `JSON Object` Windows specific initialization options.

--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -13,6 +13,7 @@ import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v4.app.NotificationCompat;
 import android.util.Log;
@@ -106,10 +107,30 @@ public class GCMIntentService extends GCMBaseIntentService {
 		
  		SharedPreferences prefs = context.getSharedPreferences("com.adobe.phonegap.push", Context.MODE_PRIVATE);
  		String localIcon = prefs.getString("icon", null);
+ 		String localIconColor = prefs.getString("iconColor", null);
 		String localLargeIcon = prefs.getString("largeIcon", null);
  		Log.d(LOG_TAG, "stored icon=" + localIcon);
+ 		Log.d(LOG_TAG, "stored iconColor=" + localIconColor);
 		Log.d(LOG_TAG, "stored largeIcon=" + localLargeIcon);
 
+		/*
+ 		 * Notification Icon Color
+ 		 *
+ 		 * Sets the small-icon background color of the notification.
+ 		 * To use, add the `iconColor` key to plugin android options
+ 		 *
+ 		 */
+		int iconColor = 0;
+		if (localIconColor != null) {
+			try {
+				iconColor = Color.parseColor(localIconColor);
+			} catch (IllegalArgumentException e) {
+				Log.e(LOG_TAG, "couldnt parse color from android options");
+			}
+		}
+		if (iconColor != 0) {
+			mBuilder.setColor(iconColor);
+		}
 
  		/*
  		 * Notification Icon

--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -9,6 +9,10 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.os.Bundle;
 import android.support.v4.app.NotificationCompat;
 import android.util.Log;
@@ -73,6 +77,8 @@ public class GCMIntentService extends GCMBaseIntentService {
 	public void createNotification(Context context, Bundle extras) {
 		NotificationManager mNotificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
 		String appName = getAppName(this);
+		String packageName = context.getPackageName();
+		Resources resources = context.getResources();
 
 		Intent notificationIntent = new Intent(this, PushHandlerActivity.class);
 		notificationIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
@@ -91,12 +97,72 @@ public class GCMIntentService extends GCMBaseIntentService {
 		NotificationCompat.Builder mBuilder =
 			new NotificationCompat.Builder(context)
 				.setDefaults(defaults)
-				.setSmallIcon(context.getApplicationInfo().icon)
 				.setWhen(System.currentTimeMillis())
 				.setContentTitle(extras.getString("title"))
 				.setTicker(extras.getString("title"))
 				.setContentIntent(contentIntent)
 				.setAutoCancel(true);
+
+		
+ 		SharedPreferences prefs = context.getSharedPreferences("com.adobe.phonegap.push", Context.MODE_PRIVATE);
+ 		String localIcon = prefs.getString("icon", null);
+		String localLargeIcon = prefs.getString("largeIcon", null);
+ 		Log.d(LOG_TAG, "stored icon=" + localIcon);
+		Log.d(LOG_TAG, "stored largeIcon=" + localLargeIcon);
+
+
+ 		/*
+ 		 * Notification Icon
+ 		 *
+ 		 * Sets the small-icon of the notification.
+ 		 * 
+ 		 * - checks the gcm data for the `icon` key
+ 		 * - if none, checks the plugin options for `icon` key
+ 		 * - if none, uses the application icon 
+ 		 *
+ 		 * The icon value must be a string that maps to a drawable resource.
+ 		 * If no resource is found, falls
+ 		 *
+ 		 */
+ 		int iconId = 0;
+ 		String gcmIcon = extras.getString("icon"); // from gcm
+ 		if (gcmIcon != null) {
+ 			iconId = resources.getIdentifier(gcmIcon, "drawable", packageName);
+ 			Log.d(LOG_TAG, "using icon from gcm");
+ 		} else if (localIcon != null) {
+ 			iconId = resources.getIdentifier(localIcon, "drawable", packageName);
+ 			Log.d(LOG_TAG, "using icon from plugin options");
+ 		}
+ 		if (iconId == 0) {
+ 			Log.d(LOG_TAG, "no icon resource found - using application icon");
+ 			iconId = context.getApplicationInfo().icon;
+ 		}
+ 		mBuilder.setSmallIcon(iconId);
+
+ 		/*
+ 		 * Notification Large-Icon
+ 		 *
+ 		 * Sets the large-icon of the notification
+ 		 *
+ 		 * - checks the gcm data for the `largeIcon` key
+ 		 * - if none, checks the plugin options for `largeIcon` key
+ 		 * - if none, we don't set the large icon
+ 		 *
+ 		 */
+ 		int largeIconId = 0;
+ 		String gcmLargeIcon = extras.getString("largeIcon"); // from gcm
+ 		if (gcmLargeIcon != null) {
+ 			largeIconId = resources.getIdentifier(gcmLargeIcon, "drawable", packageName);
+ 			Log.d(LOG_TAG, "using large-icon from gcm");	
+ 		} else if (localLargeIcon != null) {
+ 			largeIconId = resources.getIdentifier(localLargeIcon, "drawable", packageName);
+ 			Log.d(LOG_TAG, "using large-icon from plugin options");	
+ 		}
+ 		if (largeIconId != 0) {
+ 			Bitmap largeIconBitmap = BitmapFactory.decodeResource(resources, largeIconId);
+ 			mBuilder.setLargeIcon(largeIconBitmap);
+ 		}
+
 
 		String message = extras.getString("message");
 		if (message != null) {

--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -80,6 +80,11 @@ public class PushPlugin extends CordovaPlugin {
                     Log.d(LOG_TAG, "no icon option");
                 }
                 try {
+                    editor.putString("iconColor", jo.getString("iconColor"));
+                } catch (JSONException e) {
+                    Log.d(LOG_TAG, "no iconColor option");
+                }
+                try {
                     editor.putString("largeIcon", jo.getString("largeIcon"));
                 } catch (JSONException e) {
                     Log.d(LOG_TAG, "no largeIcon option");

--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -2,6 +2,7 @@ package com.adobe.phonegap.push;
 
 import android.app.NotificationManager;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.util.Log;
 
@@ -48,11 +49,12 @@ public class PushPlugin extends CordovaPlugin {
 
 		if (INITIALIZE.equals(action)) {
 			pushContext = callbackContext;
+            JSONObject jo = null;
 
 			Log.v(LOG_TAG, "execute: data=" + data.toString());
 
 			try {
-				JSONObject jo = data.getJSONObject(0).getJSONObject("android");
+                jo = data.getJSONObject(0).getJSONObject("android");
 
 				gWebView = this.webView;
 				Log.v(LOG_TAG, "execute: jo=" + jo.toString());
@@ -68,6 +70,22 @@ public class PushPlugin extends CordovaPlugin {
 				result = false;
 				callbackContext.error(e.getMessage());
 			}
+
+            if (jo != null) {
+                SharedPreferences sharedPref = getApplicationContext().getSharedPreferences("com.adobe.phonegap.push", Context.MODE_PRIVATE);
+                SharedPreferences.Editor editor = sharedPref.edit();
+                try {
+                    editor.putString("icon", jo.getString("icon"));
+                } catch (JSONException e) {
+                    Log.d(LOG_TAG, "no icon option");
+                }
+                try {
+                    editor.putString("largeIcon", jo.getString("largeIcon"));
+                } catch (JSONException e) {
+                    Log.d(LOG_TAG, "no largeIcon option");
+                }
+                editor.commit();
+            }
 
 			if ( gCachedExtras != null) {
 				Log.v(LOG_TAG, "sending cached extras");


### PR DESCRIPTION
This PR fixes the android lollipop issue displaying blank icons in issue #20 in a similar manner to what @macdonst mentioned

It adds support for both small-icon and large-icon, and gracefully falls back to how the plugin works prior to this PR if you don't set the android options

Small Icons:
- add the icon key to your android options which should be a string name of the resource to use (in res/drawables etc)
- if no android option is set, it falls back to what it currently does without this PR
- you can also override the android option key from the server by sending an icon key to GCM

Large Icons:
- add the largeIcon key to your android options which should be a string name of the resource to use (in res/drawables etc)
- if no android option is set, it does nothing
- you can also override the android option key from the server by sending a largeIcon key to GCM