### PR TITLE
Android sound fix

### DIFF
--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -201,7 +201,7 @@ public class GCMIntentService extends GCMBaseIntentService {
             }
         }
 
-        String soundname = extras.getString("soundname");
+        String soundname = extras.getString("sound");
         if (soundname != null) {
             Uri sound = Uri.parse(ContentResolver.SCHEME_ANDROID_RESOURCE
                         + "://" + context.getPackageName() + "/raw/" + soundname);


### PR DESCRIPTION
The PushPlugin sets a `sound` property when the GCM message contains `sound` or `soundname`, but the GCMIntentService was still looking for the `soundname` property.