### PR TITLE
Android option `updateNotifications`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Parameter | Description
 `options.android.sound` | `Boolean` Optional. If `true` it plays the sound specified in the push data or the default system sound. Default is `true`.
 `options.android.vibrate` | `Boolean` Optional. If `true` the device vibrates on receipt of notification. Default is `true`.
 `options.android.clearNotifications` | `Boolean` Optional. If `true` the app clears all pending notifications when it is closed. Default is `true`.
+`options.android.updateNotifications` | `Boolean` Optional. If `true` the app updates the existing notification when available. Default is `true`.
 `options.ios` | `JSON Object` iOS specific initialization options.
 `options.windows` | `JSON Object` Windows specific initialization options.
 

--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -41,7 +41,8 @@ public class GCMIntentService extends GCMBaseIntentService {
     private static final String STYLE_PICTURE = "picture";
     private static final String STYLE_TEXT = "text";
     private static ArrayList<String> messageList = new ArrayList();
-
+    private static int updateNotificationId = 0;
+    
     public void setNotification(String message){
 
         if(message == ""){
@@ -199,9 +200,15 @@ public class GCMIntentService extends GCMBaseIntentService {
          */
         createActions(extras, mBuilder, resources, packageName);
 
-        int notId = parseInt("notId", extras);
-
-        mNotificationManager.notify((String) appName, notId, mBuilder.build());
+        boolean updateNotificationsOption = prefs.getBoolean("updateNotifications", true);
+        if (updateNotificationsOption) {
+            int notId = parseInt("notId", extras);
+            mNotificationManager.notify((String) appName, notId, mBuilder.build());
+        } else {
+            mNotificationManager.notify((String) appName, updateNotificationId, mBuilder.build());
+            updateNotificationId++;
+            if (updateNotificationId >= Integer.MAX_VALUE) updateNotificationId = 0;
+        }
     }
 
     private void createActions(Bundle extras, NotificationCompat.Builder mBuilder, Resources resources, String packageName) {

--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -90,6 +90,7 @@ public class PushPlugin extends CordovaPlugin {
                 editor.putBoolean("sound", jo.optBoolean("sound", true));
                 editor.putBoolean("vibrate", jo.optBoolean("vibrate", true));
                 editor.putBoolean("clearNotifications", jo.optBoolean("clearNotifications", true));
+                editor.putBoolean("updateNotifications", jo.optBoolean("updateNotifications", true));
                 editor.commit();
             }
 


### PR DESCRIPTION
Upon receiving a notification message, the current behavior will update
the existing notification message with the new content. In some cases,
this is not the desired behavior, which is where `updateNotifications`
comes in. By setting it to to `false` (from the default `true`), each
new message will produce a new notification message.
