### PR TITLE
Bigview in inbox when only one message

### DIFF
--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -296,6 +296,13 @@ public class GCMIntentService extends GCMBaseIntentService implements PushConsta
                 }
 
                 mBuilder.setStyle(notificationInbox);
+            } else {
+                NotificationCompat.BigTextStyle bigText = new NotificationCompat.BigTextStyle();
+                if (message != null) {
+                    bigText.bigText(message);
+                    bigText.setBigContentTitle(getString(extras, TITLE));
+                    mBuilder.setStyle(bigText);
+                }
             }
         } else if (STYLE_PICTURE.equals(style)) {
             setNotification(notId, "");


### PR DESCRIPTION
Currently when there is only one message in the inbox and that message is quite long we can only see the begginning of the message.

With this PR the user can expand the notification by unwraping it and can read the full message