### PR TITLE
Support the notification coming from Parse.com when the background

### DIFF
--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -95,9 +95,23 @@ public class GCMIntentService extends GCMBaseIntentService implements PushConsta
             else {
                 extras.putBoolean(FOREGROUND, false);
 
-                // Send a notification if there is a message
                 String message = this.getMessageText(extras);
                 String title = getString(extras, TITLE, "");
+
+                // If the 'data' is present as a root object
+                // Supports Parce.com
+                if (message == null) {
+        					try {
+        						JSONObject object_example = new JSONObject(extras.getString("data"));
+        						message = object_example.getString("alert");
+                    title = object_example.getString("title");
+        						extras.putString("message", message);
+                    extras.putString("title", title);
+        					}
+        					catch (JSONException e) {}
+        				}
+
+                // Send a notification if there is a message
                 if ((message != null && message.length() != 0) ||
                         (title != null && title.length() != 0)) {
                     createNotification(context, extras);


### PR DESCRIPTION
Such as the push notification request from Parse.com, usually with different types of data will be sent.
Unfortunately, the current of this plug is not able to correspond to the format.
So, we added a program so as to correspond to Parce.com.