### PR TITLE
Remove unnecessary didRegisterUserNotificationSettings implementation, which did break cordova-local-notifications-plugin as a side effect

### DIFF
--- a/src/ios/AppDelegate+notification.h
+++ b/src/ios/AppDelegate+notification.h
@@ -13,7 +13,6 @@
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo;
 - (void)applicationDidBecomeActive:(UIApplication *)application;
-- (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings;
 - (void)application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo completionHandler:(void(^)())completionHandler;
 - (id) getCommandInstance:(NSString*)className;
 

--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -98,12 +98,6 @@ static char launchNotificationKey;
     }
 }
 
-- (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
-{
-    //register to receive notifications
-    [application registerForRemoteNotifications];
-}
-
 //For interactive notification only
 - (void)application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo completionHandler:(void(^)())completionHandler
 {

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -117,6 +117,10 @@
 }
 
 - (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+    if (self.callbackId == nil) {
+        NSLog(@"Unexpected call to didRegisterForRemoteNotificationsWithDeviceToken, ignoring: %@", deviceToken);
+        return;
+    }
     NSLog(@"Push Plugin register success: %@", deviceToken);
     
     NSMutableDictionary *results = [NSMutableDictionary dictionary];
@@ -180,6 +184,10 @@
 
 - (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
 {
+    if (self.callbackId == nil) {
+        NSLog(@"Unexpected call to didFailToRegisterForRemoteNotificationsWithError, ignoring: %@", error);
+        return;
+    }
     NSLog(@"Push Plugin register failed");
     [self failWithMessage:@"" withError:error];
 }


### PR DESCRIPTION
Problem is due to conflicting implementations of didRegisterUserNotificationSettings that prevents cordova-local-notifications-plugin from being notified of successful calls to registerUserNotificationSettings.

If implementing didRegisterUserNotificationSettings does indeed become necessary, consider using some common notification mechanism such as the one at https://github.com/katzer/cordova-common-registerusernotificationsettings to avoid conflicts with other plugins.

Fixes phonegap/phonegap-plugin-push#183 and katzer/cordova-plugin-local-notifications#695