### PR TITLE
Fixes for using new GcmReceiver code

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -55,7 +55,7 @@
                 android:permission="com.google.android.c2dm.permission.SEND" >
                 <intent-filter>
                     <action android:name="com.google.android.c2dm.intent.RECEIVE" />
-                    <category android:name="com.example.gcm" />
+                    <category android:name="$PACKAGE_NAME" />
                 </intent-filter>
             </receiver>
             <service
@@ -75,7 +75,7 @@
 		</config-file>
 
 		<framework src="com.android.support:support-v13:23+" />
-        <framework src="com.google.android.gms:play-services:+" />
+        <framework src="com.google.android.gms:play-services-gcm:+" />
 
 		<source-file src="src/android/com/adobe/phonegap/push/GCMIntentService.java" target-dir="src/com/adobe/phonegap/push/" />
 		<source-file src="src/android/com/adobe/phonegap/push/PushConstants.java" target-dir="src/com/adobe/phonegap/push/" />


### PR DESCRIPTION
Replace intent category "com.example.gcm" with $PACKAGE_NAME in plugin.xml.
Change play services dependancy to more specific play-services-gcm

update issue #188