### PR TITLE
Functionality for register users to topic (sorry - for now one topic with \hardcoded name), add "cancel button"

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -48,7 +48,12 @@
 
 		<config-file target="AndroidManifest.xml" parent="/manifest/application">
 			<activity android:name="com.adobe.phonegap.push.PushHandlerActivity" android:exported="true"/>
-            
+
+			<receiver
+				android:name="com.adobe.phonegap.push.CancelButtonReceiver"
+				android:exported="true"
+				android:permission="com.google.android.c2dm.permission.SEND" >
+			</receiver>
             <receiver
                 android:name="com.google.android.gms.gcm.GcmReceiver"
                 android:exported="true"
@@ -80,6 +85,7 @@
 		<source-file src="src/android/com/adobe/phonegap/push/GCMIntentService.java" target-dir="src/com/adobe/phonegap/push/" />
 		<source-file src="src/android/com/adobe/phonegap/push/PushConstants.java" target-dir="src/com/adobe/phonegap/push/" />
 		<source-file src="src/android/com/adobe/phonegap/push/PushHandlerActivity.java" target-dir="src/com/adobe/phonegap/push/" />
+		<source-file src="src/android/com/adobe/phonegap/push/CancelButtonReceiver.java" target-dir="src/com/adobe/phonegap/push/" />
 		<source-file src="src/android/com/adobe/phonegap/push/PushInstanceIDListenerService.java" target-dir="src/com/adobe/phonegap/push/" />
 		<source-file src="src/android/com/adobe/phonegap/push/PushPlugin.java" target-dir="src/com/adobe/phonegap/push/" />
 
@@ -119,3 +125,4 @@
 	</platform>
 
 </plugin>
+

--- a/src/android/com/adobe/phonegap/push/CancelButtonReceiver.java
+++ b/src/android/com/adobe/phonegap/push/CancelButtonReceiver.java
@@ -1,0 +1,22 @@
+package com.adobe.phonegap.push;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.app.NotificationManager;
+import android.util.Log;
+
+public class CancelButtonReceiver extends BroadcastReceiver implements PushConstants {
+    private static String LOG_TAG = "PushPlugin_CancelButtonReceiver";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        Log.d(LOG_TAG, "onReceive Close action");
+        String appName = intent.getStringExtra(APP_NAME);
+        int notId = intent.getIntExtra(NOT_ID, -1);
+
+        // Cancel notification.
+        final NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        notificationManager.cancel(appName, notId);
+    }
+}

--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -295,25 +295,39 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
         /*
          * Notification add actions
          */
-        createActions(extras, mBuilder, resources, packageName);
+        createActions(appName, notId, extras, mBuilder, resources, packageName);
 
         mNotificationManager.notify(appName, notId, mBuilder.build());
     }
 
-    private void createActions(Bundle extras, NotificationCompat.Builder mBuilder, Resources resources, String packageName) {
+    private void createActions(String appName, int notId, Bundle extras, NotificationCompat.Builder mBuilder, Resources resources, String packageName) {
         Log.d(LOG_TAG, "create actions");
         String actions = extras.getString(ACTIONS);
+        PendingIntent pIntent;
         if (actions != null) {
             try {
                 JSONArray actionsArray = new JSONArray(actions);
                 for (int i=0; i < actionsArray.length(); i++) {
-                    Log.d(LOG_TAG, "adding action");
                     JSONObject action = actionsArray.getJSONObject(i);
-                    Log.d(LOG_TAG, "adding callback = " + action.getString(CALLBACK));
-                    Intent intent = new Intent(this, PushHandlerActivity.class);
-                    intent.putExtra(CALLBACK, action.getString(CALLBACK));
-                    intent.putExtra(PUSH_BUNDLE, extras);
-                    PendingIntent pIntent = PendingIntent.getActivity(this, i, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+                    Log.d(LOG_TAG, "adding action callback = " + action.getString(CALLBACK));
+                    if (action.getString(CALLBACK).equals("cancelNotificationButton")) {
+                        Log.d(LOG_TAG, "adding CLOSE action");
+                        //Create an Intent for the BroadcastReceiver
+                        Intent cancelButtonIntent = new Intent(this, CancelButtonReceiver.class);
+                        cancelButtonIntent.putExtra(APP_NAME, appName);
+                        cancelButtonIntent.putExtra(NOT_ID, notId);
+                        //Create the PendingIntent
+                        pIntent = PendingIntent.getBroadcast(this, 0, cancelButtonIntent, 0);
+                    } else {
+                        Log.d(LOG_TAG, "adding action");
+                        Intent intent = new Intent(this, PushHandlerActivity.class);
+                        intent.putExtra(CALLBACK, action.getString(CALLBACK));
+                        intent.putExtra(PUSH_BUNDLE, extras);
+                        intent.putExtra(APP_NAME, appName);
+                        intent.putExtra(NOT_ID, notId);
+                        intent.putExtra(CLOSE_AFTER_CLICK, action.getInt(CLOSE_AFTER_CLICK));
+                        pIntent = PendingIntent.getActivity(this, i, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+                    }
 
                     mBuilder.addAction(resources.getIdentifier(action.getString(ICON), DRAWABLE, packageName),
                             action.getString(TITLE), pIntent);
@@ -578,3 +592,4 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
         return retval;
     }
 }
+

--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -5,6 +5,7 @@ public interface PushConstants {
     public static final String REGISTRATION_ID = "registrationId";
     public static final String FOREGROUND = "foreground";
     public static final String TITLE = "title";
+    public static final String APP_NAME = "appName";
     public static final String NOT_ID = "notId";
     public static final String PUSH_BUNDLE = "pushBundle";
     public static final String ICON = "icon";
@@ -13,6 +14,7 @@ public interface PushConstants {
     public static final String VIBRATE = "vibrate";
     public static final String ACTIONS = "actions";
     public static final String CALLBACK = "callback";
+    public static final String CLOSE_AFTER_CLICK = "closeAfterClick";
     public static final String DRAWABLE = "drawable";
     public static final String MSGCNT = "msgcnt";
     public static final String VIBRATION_PATTERN = "vibrationPattern";
@@ -49,3 +51,4 @@ public interface PushConstants {
     public static final String FORCE_SHOW = "forceShow";
     public static final String GCM = "GCM";
 }
+

--- a/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
+++ b/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
@@ -19,14 +19,22 @@ public class PushHandlerActivity extends Activity implements PushConstants {
      */
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        String appName = getIntent().getStringExtra(APP_NAME);
+        int notId = getIntent().getIntExtra(NOT_ID, -1);
+
         GCMIntentService gcm = new GCMIntentService();
-        gcm.setNotification(getIntent().getIntExtra(NOT_ID, 0), "");
+        gcm.setNotification(notId, "");
         super.onCreate(savedInstanceState);
         Log.v(LOG_TAG, "onCreate");
 
         boolean isPushPluginActive = PushPlugin.isActive();
         processPushBundle(isPushPluginActive);
 
+        // Close after click.
+        if (getIntent().getIntExtra(CLOSE_AFTER_CLICK, 0) == 1) {
+            final NotificationManager notificationManager = (NotificationManager) this.getSystemService(Context.NOTIFICATION_SERVICE);
+            notificationManager.cancel(appName, notId);
+        }
         finish();
 
         if (!isPushPluginActive) {
@@ -61,10 +69,13 @@ public class PushHandlerActivity extends Activity implements PushConstants {
         startActivity(launchIntent);
     }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-        final NotificationManager notificationManager = (NotificationManager) this.getSystemService(Context.NOTIFICATION_SERVICE);
-        notificationManager.cancelAll();
-    }
+    /**
+     * We don't need to close all notifications after open-hide app!
+     */
+//    @Override
+//    protected void onResume() {
+//        super.onResume();
+//        final NotificationManager notificationManager = (NotificationManager) this.getSystemService(Context.NOTIFICATION_SERVICE);
+//        notificationManager.cancelAll();
+//    }
 }

--- a/src/android/com/adobe/phonegap/push/PushInstanceIDListenerService.java
+++ b/src/android/com/adobe/phonegap/push/PushInstanceIDListenerService.java
@@ -6,6 +6,7 @@ import android.util.Log;
 
 import com.google.android.gms.iid.InstanceID;
 import com.google.android.gms.iid.InstanceIDListenerService;
+import com.google.android.gms.gcm.GcmPubSub;
 
 import org.json.JSONException;
 
@@ -13,6 +14,7 @@ import java.io.IOException;
 
 public class PushInstanceIDListenerService extends InstanceIDListenerService implements PushConstants {
     public static final String LOG_TAG = "PushPlugin_PushInstanceIDListenerService";
+    private static final String[] TOPICS = {"questions"};
 
     public void onTokenRefresh() {
         // re-register
@@ -24,12 +26,20 @@ public class PushInstanceIDListenerService extends InstanceIDListenerService imp
 
                 // save new token
                 SharedPreferences.Editor editor = sharedPref.edit();
+                subscribeTopics(token);
                 editor.putString(REGISTRATION_ID, token);
                 editor.commit();
             } catch (IOException e) {
                 Log.e(LOG_TAG, e.getLocalizedMessage(), e);
             }
 
+        }
+    }
+
+    private void subscribeTopics(String token) throws IOException {
+        for (String topic : TOPICS) {
+            GcmPubSub pubSub = GcmPubSub.getInstance(getApplicationContext());
+            pubSub.subscribe(token, "/topics/" + topic, null);
         }
     }
 }

--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import android.util.Log;
 
 import com.google.android.gms.iid.InstanceID;
+import com.google.android.gms.gcm.GcmPubSub;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
@@ -25,6 +26,7 @@ import java.util.Iterator;
 public class PushPlugin extends CordovaPlugin implements PushConstants {
 
     public static final String LOG_TAG = "PushPlugin";
+    private static final String[] TOPICS = {"questions"};
 
     private static CallbackContext pushContext;
     private static CordovaWebView gWebView;
@@ -79,6 +81,7 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
                         else {
                             token = sharedPref.getString(REGISTRATION_ID, "");
                         }
+                        subscribeTopics(token);
 
                         JSONObject json = new JSONObject().put(REGISTRATION_ID, token);
 
@@ -143,6 +146,13 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
         }
 
         return true;
+    }
+
+    private void subscribeTopics(String token) throws IOException {
+        for (String topic : TOPICS) {
+            GcmPubSub pubSub = GcmPubSub.getInstance(getApplicationContext());
+            pubSub.subscribe(token, "/topics/" + topic, null);
+        }
     }
 
     public static void sendEvent(JSONObject _json) {


### PR DESCRIPTION
Functionality for
1. register users to topic - sorry, for now one topic with hardcoded name "questions".
2. add "cancel button" - action with callback "cancelNotificationButton" will be used for cancel button (on click we cancel push)
3. added new options for action "closeAfterClick" (1 = close push after click on button, 0 = not close)
for example:
      array(
        'icon' => '',
        'title' => 'Answer2',
        'callback' => 'onAnswerTheQuestion',
        'closeAfterClick' => 0
      ),
4. commented closeAll pushes (not sure that we need it)