### PR TITLE
add sound default statement

### DIFF
--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -75,7 +75,7 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
             else if (forceShow && PushPlugin.isInForeground()) {
                 Log.d(LOG_TAG, "foreground force");
                 extras.putBoolean(FOREGROUND, true);
-                
+
                 showNotificationIfPossible(getApplicationContext(), extras);
             }
             // if we are not in the foreground always send notification if the data has at least a message or title
@@ -440,7 +440,7 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
         if (soundname == null) {
             soundname = extras.getString(SOUND);
         }
-        if (soundname != null) {
+        if (soundname != null && !soundname.contentEquals(SOUND_DEFAULT)) {
             Uri sound = Uri.parse(ContentResolver.SCHEME_ANDROID_RESOURCE
                     + "://" + context.getPackageName() + "/raw/" + soundname);
             Log.d(LOG_TAG, sound.toString());

--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -10,6 +10,7 @@ public interface PushConstants {
     public static final String ICON = "icon";
     public static final String ICON_COLOR = "iconColor";
     public static final String SOUND = "sound";
+    public static final String SOUND_DEFAULT = "default";
     public static final String VIBRATE = "vibrate";
     public static final String ACTIONS = "actions";
     public static final String CALLBACK = "callback";


### PR DESCRIPTION
Hi, there is a problem about android sound

ios will ring by setting sound as 'default' even app was not in background or foreground, 

but android will take 'default' value as a media file, 

i think android should provide 'default' value to indicate system default sound,

according to gcm document : https://developers.google.com/cloud-messaging/http-server-ref#table2

that is the reason for this pull request