### PR TITLE
Now calling .trim() to each array String element when parsing them to Ints/Longs

### DIFF
--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -364,7 +364,7 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
             long[] results = new long[items.length];
             for (int i = 0; i < items.length; i++) {
                 try {
-                    results[i] = Long.parseLong(items[i]);
+                    results[i] = Long.parseLong(items[i].trim());
                 } catch (NumberFormatException nfe) {}
             }
             mBuilder.setVibrate(results);
@@ -471,7 +471,7 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
             int[] results = new int[items.length];
             for (int i = 0; i < items.length; i++) {
                 try {
-                    results[i] = Integer.parseInt(items[i]);
+                    results[i] = Integer.parseInt(items[i].trim());
                 } catch (NumberFormatException nfe) {}
             }
             if (results.length == 4) {


### PR DESCRIPTION
When a vibration pattern is sent as e.g. [0, 150, 250, 100], or a ledColor as e.g. [0, 255, 127, 64], the space after each comma will now be trimmed, which would otherwise cause a NumberFormatException when trying to parseInt/parseLong the string " 0255".