### PR TITLE
forceShow on ios

### DIFF
--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -33,8 +33,8 @@ static char launchNotificationKey;
 - (AppDelegate *)swizzled_init
 {
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(createNotificationChecker:)
-                name:@"UIApplicationDidFinishLaunchingNotification" object:nil];
-    
+               name:@"UIApplicationDidFinishLaunchingNotification" object:nil];
+
     // This actually calls the original init method over in AppDelegate. Equivilent to calling super
     // on an overrided method, this is not recursive, although it appears that way. neat huh?
     return [self swizzled_init];

--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -24,7 +24,7 @@ static char launchNotificationKey;
 + (void)load
 {
     Method original, swizzled;
-    
+
     original = class_getInstanceMethod(self, @selector(init));
     swizzled = class_getInstanceMethod(self, @selector(swizzled_init));
     method_exchangeImplementations(original, swizzled);
@@ -33,7 +33,7 @@ static char launchNotificationKey;
 - (AppDelegate *)swizzled_init
 {
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(createNotificationChecker:)
-                                                 name:@"UIApplicationDidFinishLaunchingNotification" object:nil];
+                      name:@"UIApplicationDidFinishLaunchingNotification" object:nil];
     
     // This actually calls the original init method over in AppDelegate. Equivilent to calling super
     // on an overrided method, this is not recursive, although it appears that way. neat huh?
@@ -80,8 +80,7 @@ static char launchNotificationKey;
     // we force the notification, by default ios won't show the notification when in foreground so we create a local one
     else if (pushHandler.forceShow) {
         NSLog(@"force show");
-        NSLog(@"%@", [userInfo valueForKey:@"aps"]);
-        
+
         UILocalNotification *localNotification = [[UILocalNotification alloc] init];
         localNotification.userInfo = userInfo;
         localNotification.soundName = [[userInfo valueForKey:@"aps"] valueForKey:@"sound"];
@@ -89,7 +88,7 @@ static char launchNotificationKey;
         localNotification.applicationIconBadgeNumber = [[[userInfo valueForKey:@"aps"] valueForKey:@"badge"] intValue];
         localNotification.fireDate = [NSDate date];
         [[UIApplication sharedApplication] scheduleLocalNotification:localNotification];
-        
+
         //save it for later
         self.launchNotification = userInfo;
         
@@ -137,7 +136,7 @@ static char launchNotificationKey;
 
 - (void)applicationDidBecomeActive:(UIApplication *)application {
     NSLog(@"active");
-    
+
     PushPlugin *pushHandler = [self getCommandInstance:@"PushNotification"];
     if (pushHandler.clearBadge) {
         NSLog(@"PushPlugin clearing badge");
@@ -146,7 +145,7 @@ static char launchNotificationKey;
     } else {
         NSLog(@"PushPlugin skip clear badge");
     }
-    
+
     if (self.launchNotification) {
         pushHandler.isInline = NO;
         pushHandler.notificationMessage = self.launchNotification;
@@ -170,7 +169,7 @@ static char launchNotificationKey;
 // http://developer.apple.com/library/ios/#documentation/cocoa/conceptual/objectivec/Chapters/ocAssociativeReferences.html
 - (NSMutableArray *)launchNotification
 {
-    return objc_getAssociatedObject(self, &launchNotificationKey);
+   return objc_getAssociatedObject(self, &launchNotificationKey);
 }
 
 - (void)setLaunchNotification:(NSDictionary *)aDictionary

--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -33,7 +33,7 @@ static char launchNotificationKey;
 - (AppDelegate *)swizzled_init
 {
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(createNotificationChecker:)
-                      name:@"UIApplicationDidFinishLaunchingNotification" object:nil];
+                name:@"UIApplicationDidFinishLaunchingNotification" object:nil];
     
     // This actually calls the original init method over in AppDelegate. Equivilent to calling super
     // on an overrided method, this is not recursive, although it appears that way. neat huh?

--- a/src/ios/PushPlugin.h
+++ b/src/ios/PushPlugin.h
@@ -34,6 +34,7 @@
     NSString *notificationCallbackId;
     NSString *callback;
     BOOL    clearBadge;
+    BOOL    forceShow;
     
     NSDictionary *handlerObj;
     void (^completionHandler)(UIBackgroundFetchResult);
@@ -48,6 +49,7 @@
 @property (nonatomic, strong) NSDictionary *notificationMessage;
 @property BOOL isInline;
 @property BOOL clearBadge;
+@property BOOL forceShow;
 @property (nonatomic, strong) NSDictionary *handlerObj;
 
 - (void)init:(CDVInvokedUrlCommand*)command;

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -278,7 +278,7 @@
 {
     NSMutableDictionary* options = [command.arguments objectAtIndex:0];
     int badge = [[options objectForKey:@"badge"] intValue] ?: 0;
-    
+
     [[UIApplication sharedApplication] setApplicationIconBadgeNumber:badge];
     
     NSString* message = [NSString stringWithFormat:@"app badge count set to %d", badge];
@@ -318,13 +318,13 @@
     [self.commandDelegate runInBackground:^ {
         UIApplication *app = [UIApplication sharedApplication];
         float finishTimer = (app.backgroundTimeRemaining > 20.0) ? 20.0 : app.backgroundTimeRemaining;
-        
-        [NSTimer scheduledTimerWithTimeInterval:finishTimer
-                                         target:self
-                                       selector:@selector(stopBackgroundTask:)
-                                       userInfo:nil
-                                        repeats:NO];
-        
+    
+        [NSTimer scheduledTimerWithTimeInterval:[finishTimer
+                                     target:self
+                                    selector:@selector(stopBackgroundTask:)
+                                    userInfo:nil
+                                     repeats:NO];
+
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -319,11 +319,11 @@
         UIApplication *app = [UIApplication sharedApplication];
         float finishTimer = (app.backgroundTimeRemaining > 20.0) ? 20.0 : app.backgroundTimeRemaining;
     
-        [NSTimer scheduledTimerWithTimeInterval:[finishTimer
-                                     target:self
-                                    selector:@selector(stopBackgroundTask:)
-                                    userInfo:nil
-                                     repeats:NO];
+        [NSTimer scheduledTimerWithTimeInterval:finishTimer
+                                    target:self
+                                   selector:@selector(stopBackgroundTask:)
+                                   userInfo:nil
+                                    repeats:NO];
 
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -314,7 +314,7 @@
 -(void) finish:(CDVInvokedUrlCommand*)command
 {
     NSLog(@"Push Plugin finish called");
-    
+
     [self.commandDelegate runInBackground:^ {
         UIApplication *app = [UIApplication sharedApplication];
         float finishTimer = (app.backgroundTimeRemaining > 20.0) ? 20.0 : app.backgroundTimeRemaining;

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -289,7 +289,7 @@
 - (void)getApplicationIconBadgeNumber:(CDVInvokedUrlCommand *)command
 {
     NSInteger badge = [UIApplication sharedApplication].applicationIconBadgeNumber;
-    
+
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsInt:(int)badge];
     [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
 }
@@ -320,7 +320,7 @@
         float finishTimer = (app.backgroundTimeRemaining > 20.0) ? 20.0 : app.backgroundTimeRemaining;
     
         [NSTimer scheduledTimerWithTimeInterval:finishTimer
-                                    target:self
+                                     target:self
                                    selector:@selector(stopBackgroundTask:)
                                    userInfo:nil
                                     repeats:NO];


### PR DESCRIPTION
* works :tada: 
* not sure what happened with the styling there(I blame xcode) but I will fix this no worries
* what is not working
    * no sound or vibration on `forceShow` when in foreground (ios thing?)
    * when app is open and notification from `forceShow `is made and you drag down the notifications center and then push it back up, `appDidBecomeActive` is called and the notification is 'executed'. I do not know enough cordova api or ios api stuff to fix this. :sos: 

* any suggestions for improvements welcome!

EDIT yes I will squash those commits when done :stuck_out_tongue_winking_eye: 