### PR TITLE
Uses current flavor app id

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -43,8 +43,8 @@
 			<uses-permission android:name="android.permission.WAKE_LOCK" />
 			<uses-permission android:name="android.permission.VIBRATE"/>
 			<uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
-			<permission android:name="$PACKAGE_NAME.permission.C2D_MESSAGE" android:protectionLevel="signature" />
-			<uses-permission android:name="$PACKAGE_NAME.permission.C2D_MESSAGE" />
+			<permission android:name="${applicationId}.permission.C2D_MESSAGE" android:protectionLevel="signature" />
+			<uses-permission android:name="${applicationId}.permission.C2D_MESSAGE" />
 		</config-file>
 
 		<config-file target="AndroidManifest.xml" parent="/manifest/application">
@@ -56,7 +56,7 @@
                 android:permission="com.google.android.c2dm.permission.SEND" >
                 <intent-filter>
                     <action android:name="com.google.android.c2dm.intent.RECEIVE" />
-                    <category android:name="$PACKAGE_NAME" />
+                    <category android:name="${applicationId}" />
                 </intent-filter>
             </receiver>
             <service


### PR DESCRIPTION
Currently the plugin pulls the `PACKAGE_NAME`, early on in the build process. After working with Android product flavors where I am building different APKs with different applicationIds (com.test.app.alpha, com.test.app.beta, com.test.app) the permission still sticks with the core package name. These permission requests then conflict with each other when having multiple APKs on the same device, and can even stop the app from being downloaded from the Play Store if the user has an another app on the device with the same permissions.

By using `{applicationId}` it will grab the current App flavor's application ID later on so the current ID is used instead.

applicationId is fairly recent, so I am unsure about backwards compatibility with this fix. I've done 'some' testing too, but nothing thorough at this stage.