### PR TITLE
fix stopBackgroundTask not called from timer when executed in background

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -316,11 +316,13 @@
         UIApplication *app = [UIApplication sharedApplication];
         float finishTimer = (app.backgroundTimeRemaining > 20.0) ? 20.0 : app.backgroundTimeRemaining;
     
-        [NSTimer scheduledTimerWithTimeInterval:finishTimer
-                                     target:self
-                                   selector:@selector(stopBackgroundTask:)
-                                   userInfo:nil
-                                    repeats:NO];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [NSTimer scheduledTimerWithTimeInterval:finishTimer
+                                       target:self
+                                       selector:@selector(stopBackgroundTask:)
+                                       userInfo:nil
+                                       repeats:NO];
+        });
 
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];


### PR DESCRIPTION
On iOS, when a silent push is received (`{content-available:1}`), calling the `finish` method in `PushPlugin.m` checks the background remaining time, and schedules a timer to call `stopBackgroundTask`. 
However, since this call is wrapped to run in the background the timer doesn't work and `stopBackgroundTask` is never being called.

This pull request fixes this issue by wrapping the call with timer with `dispatch_async `