### PR TITLE
Fix method swizzling on ios

### DIFF
--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -23,11 +23,17 @@ static char launchNotificationKey;
 // Instead we will use method swizzling. we set this up in the load call.
 + (void)load
 {
-    Method original, swizzled;
+    Method original_init, swizzled_init;
 
-    original = class_getInstanceMethod(self, @selector(init));
-    swizzled = class_getInstanceMethod(self, @selector(notification_init));
-    method_exchangeImplementations(original, swizzled);
+    original_init = class_getInstanceMethod(self, @selector(init));
+    swizzled_init = class_getInstanceMethod(self, @selector(notification_init));
+    method_exchangeImplementations(original_init, swizzled_init);
+
+    Method original_applicationDidBecomeActive, swizzled_applicationDidBecomeActive;
+
+    original_applicationDidBecomeActive = class_getInstanceMethod(self, @selector(applicationDidBecomeActive:));
+    swizzled_applicationDidBecomeActive = class_getInstanceMethod(self, @selector(notification_applicationDidBecomeActive:));
+    method_exchangeImplementations(original_applicationDidBecomeActive, swizzled_applicationDidBecomeActive);
 }
 
 - (AppDelegate *)notification_init
@@ -115,7 +121,9 @@ static char launchNotificationKey;
     }
 }
 
-- (void)applicationDidBecomeActive:(UIApplication *)application {
+- (void)notification_applicationDidBecomeActive:(UIApplication *)application {
+
+    [self notification_applicationDidBecomeActive:application];
 
     NSLog(@"active");
 

--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -26,18 +26,18 @@ static char launchNotificationKey;
     Method original, swizzled;
 
     original = class_getInstanceMethod(self, @selector(init));
-    swizzled = class_getInstanceMethod(self, @selector(swizzled_init));
+    swizzled = class_getInstanceMethod(self, @selector(notification_init));
     method_exchangeImplementations(original, swizzled);
 }
 
-- (AppDelegate *)swizzled_init
+- (AppDelegate *)notification_init
 {
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(createNotificationChecker:)
                name:@"UIApplicationDidFinishLaunchingNotification" object:nil];
 
     // This actually calls the original init method over in AppDelegate. Equivilent to calling super
     // on an overrided method, this is not recursive, although it appears that way. neat huh?
-    return [self swizzled_init];
+    return [self notification_init];
 }
 
 // This code will be called immediately after application:didFinishLaunchingWithOptions:. We need
@@ -72,13 +72,13 @@ static char launchNotificationKey;
         pushHandler.notificationMessage = userInfo;
         pushHandler.isInline = YES;
         [pushHandler notificationReceived];
-        
+
         completionHandler(UIBackgroundFetchResultNewData);
     }
     // app is in background or in stand by
     else {
         NSLog(@"app in-active");
-        
+
         // do some convoluted logic to find out if this should be a silent push.
         long silent = 0;
         id aps = [userInfo objectForKey:@"aps"];
@@ -88,7 +88,7 @@ static char launchNotificationKey;
         } else if ([contentAvailable isKindOfClass:[NSNumber class]]) {
             silent = [contentAvailable integerValue];
         }
-        
+
         if (silent == 1) {
             NSLog(@"this should be a silent push");
             void (^safeHandler)(UIBackgroundFetchResult) = ^(UIBackgroundFetchResult result){
@@ -96,10 +96,10 @@ static char launchNotificationKey;
                     completionHandler(result);
                 });
             };
-            
+
             NSMutableDictionary* params = [NSMutableDictionary dictionaryWithCapacity:2];
             [params setObject:safeHandler forKey:@"handler"];
-            
+
             PushPlugin *pushHandler = [self getCommandInstance:@"PushNotification"];
             pushHandler.notificationMessage = userInfo;
             pushHandler.isInline = NO;
@@ -109,7 +109,7 @@ static char launchNotificationKey;
             NSLog(@"just put it in the shade");
             //save it for later
             self.launchNotification = userInfo;
-            
+
             completionHandler(UIBackgroundFetchResultNewData);
         }
     }
@@ -123,7 +123,7 @@ static char launchNotificationKey;
     if (pushHandler.clearBadge) {
         NSLog(@"PushPlugin clearing badge");
         //zero badge
-        application.applicationIconBadgeNumber = 0;        
+        application.applicationIconBadgeNumber = 0;
     } else {
         NSLog(@"PushPlugin skip clear badge");
     }


### PR DESCRIPTION
renamed `swizzled_init` to `notification_init` to avoid potential name collisions + its better practice to prefix swizzled methods with the name of the category.

swizzled `applicationDidBecomeActive:` as `notification_applicationDidBecomeActive:` and decided to call the original at the top of this method.