### PR TITLE
Android Implementation #407 Interpolate UTC to Local Timestamp

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -90,6 +90,15 @@
 		<source-file src="src/android/com/adobe/phonegap/push/PushPlugin.java" target-dir="src/com/adobe/phonegap/push/" />
         <source-file src="src/android/com/adobe/phonegap/push/RegistrationIntentService.java" target-dir="src/com/adobe/phonegap/push/" />
         <source-file src="src/android/com/adobe/phonegap/push/PermissionUtils.java" target-dir="src/com/adobe/phonegap/push/" />
+	<source-file src="src/android/com/adobe/phonegap/push/formatters/AbstractTimestampParser.java" target-dir="src/com/adobe/phonegap/push/formatters/" />
+	<source-file src="src/android/com/adobe/phonegap/push/formatters/Localize.java" target-dir="src/com/adobe/phonegap/push/formatters/" />
+	<source-file src="src/android/com/adobe/phonegap/push/formatters/LocalizeCurrency.java" target-dir="src/com/adobe/phonegap/push/formatters/" />
+	<source-file src="src/android/com/adobe/phonegap/push/formatters/LocalizeDate.java" target-dir="src/com/adobe/phonegap/push/formatters/" />
+	<source-file src="src/android/com/adobe/phonegap/push/formatters/LocalizeDateTime.java" target-dir="src/com/adobe/phonegap/push/formatters/" />
+	<source-file src="src/android/com/adobe/phonegap/push/formatters/LocalizeFormatter.java" target-dir="src/com/adobe/phonegap/push/formatters/" />
+	<source-file src="src/android/com/adobe/phonegap/push/formatters/LocalizeTime.java" target-dir="src/com/adobe/phonegap/push/formatters/" />
+
+
 
 	</platform>
 

--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -19,6 +19,7 @@ import android.support.v4.app.NotificationCompat;
 import android.text.Html;
 import android.util.Log;
 
+import com.adobe.phonegap.push.formatters.LocalizeFormatter;
 import com.google.android.gms.gcm.GcmListenerService;
 
 import org.json.JSONArray;
@@ -29,6 +30,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -64,6 +66,7 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
             boolean forceShow = prefs.getBoolean(FORCE_SHOW, false);
 
             extras = normalizeExtras(extras);
+            formatIfNecessary(extras);
 
             // if we are in the foreground and forceShow is `false` only send data
             if (!forceShow && PushPlugin.isInForeground()) {
@@ -215,6 +218,15 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
             PushPlugin.sendExtras(extras);
         }
     }
+    
+    private void formatIfNecessary(Bundle extras) {
+   	 String message = extras.getString(MESSAGE);
+		if(message.contains("format")){
+			Log.d(LOG_TAG, "message =[" + message + "] Needs format.");
+			final String formattedMessage = new LocalizeFormatter().localize(message);
+			extras.putString(MESSAGE, formattedMessage);
+		}
+  	}
 
     public void createNotification(Context context, Bundle extras) {
         NotificationManager mNotificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);

--- a/src/android/com/adobe/phonegap/push/formatters/AbstractTimestampParser.java
+++ b/src/android/com/adobe/phonegap/push/formatters/AbstractTimestampParser.java
@@ -1,0 +1,30 @@
+package com.adobe.phonegap.push.formatters;
+
+import static com.adobe.phonegap.push.PushPlugin.LOG_TAG;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import android.util.Log;
+
+public abstract class AbstractTimestampParser {
+	protected int style(String style) {
+		if ("SHORT".equals(style)) { return DateFormat.SHORT; }
+		if ("MEDIUM".equals(style)) { return DateFormat.MEDIUM; }
+		if ("LONG".equals(style)) { return DateFormat.LONG; }
+		if ("FULL".equals(style)) { return DateFormat.FULL; }
+		return DateFormat.DEFAULT;
+	}
+
+	protected Date parse(String date) {
+		try {
+			final DateFormat utcParser = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssz");
+			return utcParser.parse(date);
+		} catch (ParseException e) {
+			Log.e(LOG_TAG, "AbstractTimestampParser: Couldn't parse date " + date, e);
+			return null;
+		}
+	}
+}

--- a/src/android/com/adobe/phonegap/push/formatters/Localize.java
+++ b/src/android/com/adobe/phonegap/push/formatters/Localize.java
@@ -1,0 +1,6 @@
+package com.adobe.phonegap.push.formatters;
+
+
+public interface Localize {
+	public String localize(String raw);
+}

--- a/src/android/com/adobe/phonegap/push/formatters/LocalizeCurrency.java
+++ b/src/android/com/adobe/phonegap/push/formatters/LocalizeCurrency.java
@@ -1,0 +1,28 @@
+package com.adobe.phonegap.push.formatters;
+
+import static com.adobe.phonegap.push.PushPlugin.LOG_TAG;
+import static java.lang.String.format;
+
+import java.math.BigDecimal;
+import java.text.NumberFormat;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import android.util.Log;
+
+public class LocalizeCurrency extends AbstractTimestampParser implements Localize {
+	private final Pattern pattern = //
+	Pattern.compile("format\\('([+-]?[0-9]{1,3}(?:,?[0-9]{3})*\\.[0-9]{2})', '(CURRENCY)'\\)");
+
+	public String localize(String raw) {
+		final Matcher matcher = pattern.matcher(raw);
+		if (matcher.find()) {
+			final BigDecimal value = new BigDecimal(matcher.group(1));
+			String currency = NumberFormat.getCurrencyInstance().format(value);
+			final String newMessage = raw.replaceAll(pattern.pattern(), Matcher.quoteReplacement(currency));
+			Log.v(LOG_TAG, format("LocalizeCurrency: Message formatted, new message is %s.", newMessage));
+			return newMessage;
+		}
+		return raw;
+	}
+}

--- a/src/android/com/adobe/phonegap/push/formatters/LocalizeDate.java
+++ b/src/android/com/adobe/phonegap/push/formatters/LocalizeDate.java
@@ -1,0 +1,34 @@
+package com.adobe.phonegap.push.formatters;
+
+import static com.adobe.phonegap.push.PushPlugin.LOG_TAG;
+import static java.lang.String.format;
+
+import java.text.DateFormat;
+import java.util.Date;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import android.util.Log;
+
+public class LocalizeDate extends AbstractTimestampParser implements Localize {
+	private final Pattern pattern = //
+	Pattern.compile("format\\('(\\d{4}-\\d{2}-\\d{2})T(\\d{2}:\\d{2}:\\d{2})\\.?\\d*Z\\',\\s*'(DATE):*(SHORT|MEDIUM|LONG|FULL|DEFAULT)*'\\)");
+
+	public String localize(String raw) {
+		final Matcher matcher = pattern.matcher(raw);
+		if (matcher.find()) {
+			final Date localdate = parse(matcher.group(1) + "T" + matcher.group(2) + "GMT-00:00");
+			if (localdate == null) {
+				Log.e(LOG_TAG, "LocalizeDate: Couldn't format message.");
+				return raw;
+			}
+			final int style = matcher.groupCount() >= 4 ? style(matcher.group(4)) : DateFormat.DEFAULT;
+			final DateFormat formatter = DateFormat.getDateInstance(style);
+			final String newMessage = raw.replaceAll(pattern.pattern(), formatter.format(localdate));
+			Log.v(LOG_TAG, format("LocalizeDate: Message formatted, new message is %s.", newMessage));
+			return newMessage;
+		}
+
+		return raw;
+	}
+}

--- a/src/android/com/adobe/phonegap/push/formatters/LocalizeDateTime.java
+++ b/src/android/com/adobe/phonegap/push/formatters/LocalizeDateTime.java
@@ -1,0 +1,35 @@
+package com.adobe.phonegap.push.formatters;
+
+import static com.adobe.phonegap.push.PushPlugin.LOG_TAG;
+import static java.lang.String.format;
+
+import java.text.DateFormat;
+import java.util.Date;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import android.util.Log;
+
+public class LocalizeDateTime extends AbstractTimestampParser implements Localize {
+	private final Pattern pattern = //
+	Pattern
+			.compile("format\\('(\\d{4}-\\d{2}-\\d{2})T(\\d{2}:\\d{2}:\\d{2})\\.?\\d*Z\\',\\s*'(DATETIME):*(SHORT|MEDIUM|LONG|FULL|DEFAULT)*\\,*\\s*(SHORT|MEDIUM|LONG|FULL|DEFAULT)*'\\)");
+
+	public String localize(String raw) {
+		final Matcher matcher = pattern.matcher(raw);
+		if (matcher.find()) {
+			final Date localdate = parse(matcher.group(1) + "T" + matcher.group(2) + "GMT-00:00");
+			if (localdate == null) {
+				Log.e(LOG_TAG, "LocalizeDateTime: Couldn't format message.");
+				return raw;
+			}
+			final int dateStyle = matcher.groupCount() >= 4 ? style(matcher.group(4)) : DateFormat.DEFAULT;
+			final int timeStyle = matcher.groupCount() >= 5 ? style(matcher.group(5)) : DateFormat.DEFAULT;
+			final DateFormat formatter = DateFormat.getDateTimeInstance(dateStyle, timeStyle);
+			final String newMessage = raw.replaceAll(pattern.pattern(), formatter.format(localdate));
+			Log.v(LOG_TAG, format("LocalizeDateTime: Message formatted, new message is %s.", newMessage));
+			return newMessage;
+		}
+		return raw;
+	}
+}

--- a/src/android/com/adobe/phonegap/push/formatters/LocalizeFormatter.java
+++ b/src/android/com/adobe/phonegap/push/formatters/LocalizeFormatter.java
@@ -1,0 +1,23 @@
+package com.adobe.phonegap.push.formatters;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class LocalizeFormatter implements Localize {
+	private static final List<Localize> LOCALIZERS = new ArrayList<Localize>();
+
+	static {
+		LOCALIZERS.add(new LocalizeDate());
+		LOCALIZERS.add(new LocalizeTime());
+		LOCALIZERS.add(new LocalizeDateTime());
+		LOCALIZERS.add(new LocalizeCurrency());
+	}
+
+	public String localize(String raw) {
+		String message = raw;
+		for (Localize localize : LOCALIZERS) {
+			message = localize.localize(message);
+		}
+		return message;
+	}
+}

--- a/src/android/com/adobe/phonegap/push/formatters/LocalizeTime.java
+++ b/src/android/com/adobe/phonegap/push/formatters/LocalizeTime.java
@@ -1,0 +1,33 @@
+package com.adobe.phonegap.push.formatters;
+
+import static com.adobe.phonegap.push.PushPlugin.LOG_TAG;
+import static java.lang.String.format;
+
+import java.text.DateFormat;
+import java.util.Date;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import android.util.Log;
+
+public class LocalizeTime extends AbstractTimestampParser implements Localize {
+	private final Pattern pattern = //
+	Pattern.compile("format\\('(\\d{4}-\\d{2}-\\d{2})T(\\d{2}:\\d{2}:\\d{2})\\.?\\d*Z\\',\\s*'(TIME):*(SHORT|MEDIUM|LONG|FULL|DEFAULT)*'\\)");
+
+	public String localize(String raw) {
+		final Matcher matcher = pattern.matcher(raw);
+		if (matcher.find()) {
+			final Date localdate = parse(matcher.group(1) + "T" + matcher.group(2) + "GMT-00:00");
+			if (localdate == null) {
+				Log.e(LOG_TAG, "LocalizeTime: Couldn't format message.");
+				return raw;
+			}
+			final int style = matcher.groupCount() >= 4 ? style(matcher.group(4)) : DateFormat.DEFAULT;
+			final DateFormat formatter = DateFormat.getTimeInstance(style);
+			final String newMessage = raw.replaceAll(pattern.pattern(), formatter.format(localdate));
+			Log.v(LOG_TAG, format("LocalizeTime: Message formatted, new message is %s.", newMessage));
+			return newMessage;
+		}
+		return raw;
+	}
+}


### PR DESCRIPTION
So, @macdonst I did this implementation for android.
Considering that you pass in the message something like that
- format('2015-12-23T14:59:08.000Z', 'DATETIME:FULL,MEDIUM')  
  (  e.g  Hello your appointment is at format('2015-12-23T14:59:08.000Z', 'DATETIME:FULL,MEDIUM')  )

If your language is PT-BT like mine the message will be show
- quarta-feira, 23 de dezembro de 2015 12:59:08 PM  (i.e wednesday, december 23 of 2015 12:59:08 PM .... Something like that in English)

There is several ways you can format the timestamp, where some examples.
- format('2015-12-09T01:24:00.000Z', 'DATE')
- format('2015-12-09T01:24:00.000Z', 'TIME')
- format('2015-12-09T01:24:00.000Z', 'DATETIME')
- format('2015-12-09T01:24:00.000Z', 'DATE:SHORT')
- format('2015-12-09T01:24:00.000Z', 'DATE:FULL')

Only DATETIME needs two styles, one for date and another for time, if you don't pass any the system default will be used.
- format('2015-12-09T01:24:00.000Z', 'DATETIME')
- format('2015-12-09T01:24:00.000Z', 'DATETIME:MEDIUM,MEDIUM')

*\* Problems
- I don't have a Mac OS, I don't even now objective-c, perhaps someone else can do that, can you do it  ??  :)
