### PR TITLE
Force running the application if it was closed (Issue #333)

### DIFF
--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -197,6 +197,7 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
         String message = extras.getString(MESSAGE);
         String title = extras.getString(TITLE);
         String forceLaunch = extras.getString(FORCE_LAUNCH);
+        String startOnBackground = extras.getString(START_ON_BACKGROUND);
 
         Log.d(LOG_TAG, "message =[" + message + "]");
         Log.d(LOG_TAG, "title =[" + title + "]");
@@ -211,6 +212,7 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
             Log.d(LOG_TAG, "force launch event");
             Intent intent = new Intent(this, PushHandlerActivity.class);
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            intent.putExtra(PUSH_BUNDLE, extras);
             startActivity(intent);
         } else {
             Log.d(LOG_TAG, "send notification event");

--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -196,6 +196,7 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
         // Send a notification if there is a message or title, otherwise just send data
         String message = extras.getString(MESSAGE);
         String title = extras.getString(TITLE);
+        String forceLaunch = extras.getString(FORCE_LAUNCH);
 
         Log.d(LOG_TAG, "message =[" + message + "]");
         Log.d(LOG_TAG, "title =[" + title + "]");
@@ -206,6 +207,11 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
             Log.d(LOG_TAG, "create notification");
 
             createNotification(context, extras);
+        } else if ("1".equals(forceLaunch)) {
+            Log.d(LOG_TAG, "force launch event");
+            Intent intent = new Intent(this, PushHandlerActivity.class);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            startActivity(intent);
         } else {
             Log.d(LOG_TAG, "send notification event");
             PushPlugin.sendExtras(extras);
@@ -364,7 +370,7 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
             long[] results = new long[items.length];
             for (int i = 0; i < items.length; i++) {
                 try {
-                    results[i] = Long.parseLong(items[i].trim());
+                    results[i] = Long.parseLong(items[i]);
                 } catch (NumberFormatException nfe) {}
             }
             mBuilder.setVibrate(results);
@@ -471,7 +477,7 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
             int[] results = new int[items.length];
             for (int i = 0; i < items.length; i++) {
                 try {
-                    results[i] = Integer.parseInt(items[i].trim());
+                    results[i] = Integer.parseInt(items[i]);
                 } catch (NumberFormatException nfe) {}
             }
             if (results.length == 4) {

--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -50,4 +50,5 @@ public interface PushConstants {
     public static final String COLLAPSE_KEY = "collapse_key";
     public static final String FORCE_SHOW = "forceShow";
     public static final String GCM = "GCM";
+    public static final String FORCE_LAUNCH = "force_launch";
 }

--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -50,5 +50,8 @@ public interface PushConstants {
     public static final String COLLAPSE_KEY = "collapse_key";
     public static final String FORCE_SHOW = "forceShow";
     public static final String GCM = "GCM";
+
+    // Two custom properties
     public static final String FORCE_LAUNCH = "force_launch";
+    public static final String START_ON_BACKGROUND = "start_on_background";
 }

--- a/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
+++ b/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
@@ -32,6 +32,7 @@ public class PushHandlerActivity extends Activity implements PushConstants {
         if (!isPushPluginActive) {
             forceMainActivityReload();
         }
+
     }
 
     /**
@@ -41,7 +42,7 @@ public class PushHandlerActivity extends Activity implements PushConstants {
     private void processPushBundle(boolean isPushPluginActive) {
         Bundle extras = getIntent().getExtras();
 
-        if (extras != null)	{
+        if (extras != null) {
             Bundle originalExtras = extras.getBundle(PUSH_BUNDLE);
 
             originalExtras.putBoolean(FOREGROUND, false);
@@ -58,6 +59,15 @@ public class PushHandlerActivity extends Activity implements PushConstants {
     private void forceMainActivityReload() {
         PackageManager pm = getPackageManager();
         Intent launchIntent = pm.getLaunchIntentForPackage(getApplicationContext().getPackageName());
+
+        Bundle extras = getIntent().getExtras();
+        if (extras != null) {
+            Bundle originalExtras = extras.getBundle(PUSH_BUNDLE);
+            if (originalExtras != null) {
+                launchIntent.putExtras(originalExtras);
+            }
+        }
+
         startActivity(launchIntent);
     }
 


### PR DESCRIPTION
Hi,

We've made some improvements to achieve running the application if it was closed at the moment of GCM notification - with bringing the app to the foreground or starting it silently on the background. This works only on the Android platform. Please review the changes and include them in the project or let me know what I should improve/change to get them included. 

Thanks.