### PR TITLE
Add setApplicationIconBadgeNumber action for Android, using ShortcutBadger

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -86,6 +86,7 @@
 
         <framework src="com.android.support:support-v13:23+" />
         <framework src="com.google.android.gms:play-services-gcm:+" />
+        <framework src="me.leolin:ShortcutBadger:1.1.4@aar" />
 
 		<source-file src="src/android/com/adobe/phonegap/push/GCMIntentService.java" target-dir="src/com/adobe/phonegap/push/" />
 		<source-file src="src/android/com/adobe/phonegap/push/PushConstants.java" target-dir="src/com/adobe/phonegap/push/" />

--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -197,10 +197,16 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
         String message = extras.getString(MESSAGE);
         String title = extras.getString(TITLE);
         String contentAvailable = extras.getString(CONTENT_AVAILABLE);
+        String badgeCount = extras.getString(COUNT);
 
         Log.d(LOG_TAG, "message =[" + message + "]");
         Log.d(LOG_TAG, "title =[" + title + "]");
         Log.d(LOG_TAG, "contentAvailable =[" + contentAvailable + "]");
+        Log.d(LOG_TAG, "badgeCount =[" + badgeCount + "]");
+
+        if (badgeCount != null) {
+            PushPlugin.setApplicationIconBadgeNumber(context, Integer.parseInt(badgeCount));
+        }
 
         if ((message != null && message.length() != 0) ||
                 (title != null && title.length() != 0)) {

--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -54,4 +54,5 @@ public interface PushConstants {
     public static final String GCM = "GCM";
     public static final String CONTENT_AVAILABLE = "content-available";
     public static final String TOPICS = "topics";
+    public static final String SET_APPLICATION_ICON_BADGE_NUMBER = "setApplicationIconBadgeNumber";
 }

--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -23,6 +23,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 
+import me.leolin.shortcutbadger.ShortcutBadger;
+
 public class PushPlugin extends CordovaPlugin implements PushConstants {
 
     public static final String LOG_TAG = "PushPlugin";
@@ -179,6 +181,18 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
                     }
                 }
             });
+        } else if (SET_APPLICATION_ICON_BADGE_NUMBER.equals(action)) {
+            cordova.getThreadPool().execute(new Runnable() {
+                public void run() {
+                    Log.v(LOG_TAG, "setApplicationIconBadgeNumber: data=" + data.toString());
+                    try {
+                        setApplicationIconBadgeNumber(getApplicationContext(), data.getJSONObject(0).getInt(BADGE));
+                    } catch (JSONException e) {
+                        callbackContext.error(e.getMessage());
+                    }
+                    callbackContext.success();
+                }
+            });
         } else {
             Log.e(LOG_TAG, "Invalid action : " + action);
             callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
@@ -216,6 +230,14 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
                 Log.v(LOG_TAG, "sendExtras: caching extras to send at a later time.");
                 gCachedExtras = extras;
             }
+        }
+    }
+
+    public static void setApplicationIconBadgeNumber(Context context, int badgeCount) {
+        if (badgeCount > 0) {
+            ShortcutBadger.applyCount(context, badgeCount);
+        } else {
+            ShortcutBadger.removeCount(context);
         }
     }
 


### PR DESCRIPTION
Adds https://github.com/leolin310148/ShortcutBadger support for Android badges, using `setApplicationIconBadgeNumber()` Fixes #622

Update: Now also handles background notifications

- [x] Use ShortcutBadger to update badges
- [x] Implement `setApplicationIconBadgeNumber()` call directly, similar to iOS (using different thread)
- [x] Update badge from GCM `count` property
