### PR TITLE
Add coldstart property for iOS

### DIFF
--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -44,11 +44,15 @@ static char launchNotificationKey;
 // to process notifications in cold-start situations
 - (void)createNotificationChecker:(NSNotification *)notification
 {
+    NSLog(@"createNotificationChecker");
+
     if (notification)
     {
         NSDictionary *launchOptions = [notification userInfo];
-        if (launchOptions)
+        if (launchOptions) {
+            NSLog(@"coldstart");
             self.launchNotification = [launchOptions objectForKey: @"UIApplicationLaunchOptionsRemoteNotificationKey"];
+        }
     }
 }
 
@@ -103,6 +107,11 @@ static char launchNotificationKey;
             PushPlugin *pushHandler = [self getCommandInstance:@"PushNotification"];
             pushHandler.notificationMessage = userInfo;
             pushHandler.isInline = NO;
+
+            if(application.applicationState == UIApplicationStateInactive) {
+                pushHandler.coldstart = [NSNumber numberWithInt:self.launchNotification? 1 : 0];
+            }
+            
             pushHandler.handlerObj = params;
             [pushHandler notificationReceived];
         } else {
@@ -142,6 +151,7 @@ static char launchNotificationKey;
 
     if (self.launchNotification) {
         pushHandler.isInline = NO;
+        pushHandler.coldstart = [NSNumber numberWithInt:self.launchNotification? 1 : 0];
         pushHandler.notificationMessage = self.launchNotification;
         self.launchNotification = nil;
         [pushHandler performSelectorOnMainThread:@selector(notificationReceived) withObject:pushHandler waitUntilDone:NO];

--- a/src/ios/PushPlugin.h
+++ b/src/ios/PushPlugin.h
@@ -48,6 +48,7 @@
 
 @property (nonatomic, strong) NSDictionary *notificationMessage;
 @property BOOL isInline;
+@property NSNumber *coldstart;
 @property BOOL clearBadge;
 @property (nonatomic, strong) NSDictionary *handlerObj;
 

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -34,6 +34,7 @@
 
 @synthesize notificationMessage;
 @synthesize isInline;
+@synthesize coldstart;
 
 @synthesize callbackId;
 @synthesize notificationCallbackId;
@@ -413,6 +414,11 @@
             [additionalData setObject:[NSNumber numberWithBool:NO] forKey:@"foreground"];
         }
 
+
+        if (coldstart != nil && [coldstart intValue] >= 0) {
+            [additionalData setObject:[NSNumber numberWithBool:[coldstart intValue] == 1] forKey:@"coldstart"];
+        }
+
         [message setObject:additionalData forKey:@"additionalData"];
 
         // send notification message
@@ -421,6 +427,7 @@
         [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
 
         self.notificationMessage = nil;
+        self.coldstart = nil;
     }
 }
 


### PR DESCRIPTION
Trying to mimic the same `coldstart` behaviour of the android version.

Like in the android version, `coldstart` has 3 different states instead of just `true | false`

- `undefined` (`coldstart` property doesn't exist in the `addtionalData` object) - `on('notification')` is triggered when the app is in either **background** or **foreground** mode

- `true` - `on('notification')` is triggered when the app is launched from a notification, and the app is in **suspended** mode

- `false` - `on('notification')` is triggered when the app is launched from a notification, and the app is in **background** mode

I've tested it fairly thoroughly with iOS 9.2 and it seems to be working fine. I'm not an Objective-C expert so I might have miss something, feel free to point them out and I'll try to fix them.

