### PR TITLE
[ios] better swizzling

### DIFF
--- a/src/ios/AppDelegate+notification.h
+++ b/src/ios/AppDelegate+notification.h
@@ -12,7 +12,7 @@
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:( void (^)(UIBackgroundFetchResult))completionHandler;
-- (void)applicationDidBecomeActive:(UIApplication *)application;
+- (void)pushPluginOnApplicationDidBecomeActive:(UIApplication *)application;
 - (void)application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo completionHandler:(void(^)())completionHandler;
 - (id) getCommandInstance:(NSString*)className;
 


### PR DESCRIPTION
This still isn't the "right way" linked in #427, but seems to be safe
and void of side effects due to the namespacing of all the methods.

It has been tested to work side by side with another plugin that also
swizzles AppDelegate's applicationDidBecomeActive.

1. wrapped swizzling in dispatch_once
2. first attempts class_addMethod / class_replaceMethod but if that
fails falls back to method_exchangeImplementations.
3. swizzled_init => pushPluginSwizzledInit (if other plugins attempt to
swizzle init and use the same name, there seems to be a collision)
4. added an observer for UIApplicationDidBecomeActiveNotification
instead of overriding applicationDidBecomeActive
5. applicationDidBecomeActive => pushPluginOnApplicationDidBecomeActive
(and it becomes a notification observer instead)

See http://nshipster.com/method-swizzling/ and "Avoid collisions" under
"Considerations".

This will need testng by someone that understands the plugin better than
I do, but it should not be changing the core functionality at all. The
pushPluginOnApplicationDidBecomeActive method *is* called when the
application becomes active, etc.

Goes a long way toward fixing #427 without regressing #447, etc.