### PR TITLE
Support android shortcut badges on supported devices when app is closed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,3 +28,4 @@ repositories {
 dependencies {
     compile 'me.leolin:ShortcutBadger:1.1.4@aar'
 }
+

--- a/plugin.xml
+++ b/plugin.xml
@@ -23,7 +23,7 @@
 	<engines>
         <engine name="cordova" version=">=3.6.3" />
         <engine name="cordova-android" version=">=4.0.0" />
-        <engine name="cordova-ios" version=">=4.0.0" />
+        <engine name="cordova-ios" version=">=3.9.2" />
     </engines>
 
     <preference name="SENDER_ID" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -86,6 +86,7 @@
 
         <framework src="com.android.support:support-v13:23+" />
         <framework src="com.google.android.gms:play-services-gcm:+" />
+        <framework src="build.gradle" custom="true" type="gradleReference" />
 
 		<source-file src="src/android/com/adobe/phonegap/push/GCMIntentService.java" target-dir="src/com/adobe/phonegap/push/" />
 		<source-file src="src/android/com/adobe/phonegap/push/PushConstants.java" target-dir="src/com/adobe/phonegap/push/" />

--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -59,7 +59,6 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
     @Override
     public void onMessageReceived(String from, Bundle extras) {
         Log.d(LOG_TAG, "onMessage - from: " + from);
-        ShortcutBadger.applyCount(getApplicationContext(), 3);
         if (extras != null) {
 
             SharedPreferences prefs = getApplicationContext().getSharedPreferences(PushPlugin.COM_ADOBE_PHONEGAP_PUSH, Context.MODE_PRIVATE);
@@ -193,10 +192,13 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
         return newExtras;
     }
 
-    private void updateBadge(Context context, int badge) {
-        if (badge > 0) {
-            ShortcutBadger.applyCount(context, badge);
-        } else if (badge == 0) {
+    private void updateBadge(Context context, String badge) {
+
+        count = badge == null ? 0 : Integer.parseInt(badge);
+
+        if (count > 0) {
+            ShortcutBadger.applyCount(context, count);
+        } else if (count == 0) {
             ShortcutBadger.removeCount(context);
         }
     }
@@ -208,7 +210,7 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
         String message = extras.getString(MESSAGE);
         String title = extras.getString(TITLE);
         String contentAvailable = extras.getString(CONTENT_AVAILABLE);
-        int badgeCount = extras.getInt(COUNT);
+        String badgeCount = extras.getString(COUNT);
 
         Log.d(LOG_TAG, "message =[" + message + "]");
         Log.d(LOG_TAG, "title =[" + title + "]");

--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -57,7 +57,7 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
     @Override
     public void onMessageReceived(String from, Bundle extras) {
         Log.d(LOG_TAG, "onMessage - from: " + from);
-
+        Log.d(LOG_TAG, "My new plugin! Yeaah! ");
         if (extras != null) {
 
             SharedPreferences prefs = getApplicationContext().getSharedPreferences(PushPlugin.COM_ADOBE_PHONEGAP_PUSH, Context.MODE_PRIVATE);

--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -194,7 +194,11 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
     }
 
     private void updateBadge(Context context, int badge) {
-
+        if (badge > 0) {
+            ShortcutBadger.applyCount(context, badge);
+        } else if (badge == 0) {
+            ShortcutBadger.removeCount(context);
+        }
     }
 
 
@@ -204,10 +208,14 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
         String message = extras.getString(MESSAGE);
         String title = extras.getString(TITLE);
         String contentAvailable = extras.getString(CONTENT_AVAILABLE);
+        int badgeCount = extras.getInt(COUNT);
 
         Log.d(LOG_TAG, "message =[" + message + "]");
         Log.d(LOG_TAG, "title =[" + title + "]");
         Log.d(LOG_TAG, "contentAvailable =[" + contentAvailable + "]");
+        Log.d(LOG_TAG, "badgeCount =[" + badgeCount + "]");
+
+        updateBadge(context, badgeCount);
 
         if ((message != null && message.length() != 0) ||
                 (title != null && title.length() != 0)) {

--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -25,6 +25,8 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import me.leolin.shortcutbadger.ShortcutBadger;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
@@ -57,7 +59,7 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
     @Override
     public void onMessageReceived(String from, Bundle extras) {
         Log.d(LOG_TAG, "onMessage - from: " + from);
-        Log.d(LOG_TAG, "My new plugin! Yeaah! ");
+        ShortcutBadger.applyCount(getApplicationContext(), 3);
         if (extras != null) {
 
             SharedPreferences prefs = getApplicationContext().getSharedPreferences(PushPlugin.COM_ADOBE_PHONEGAP_PUSH, Context.MODE_PRIVATE);
@@ -190,6 +192,11 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
 
         return newExtras;
     }
+
+    private void updateBadge(Context context, int badge) {
+
+    }
+
 
     private void showNotificationIfPossible (Context context, Bundle extras) {
 

--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -194,7 +194,7 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
 
     private void updateBadge(Context context, String badge) {
 
-        count = badge == null ? 0 : Integer.parseInt(badge);
+        int count = badge == null ? 0 : Integer.parseInt(badge);
 
         if (count > 0) {
             ShortcutBadger.applyCount(context, count);

--- a/src/android/com/adobe/phonegap/push/PushPlugin.gradle
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.gradle
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2013-2016 by appPlant UG. All rights reserved.
+ *
+ * @APPPLANT_LICENSE_HEADER_START@
+ *
+ * This file contains Original Code and/or Modifications of Original Code
+ * as defined in and that are subject to the Apache License
+ * Version 2.0 (the 'License'). You may not use this file except in
+ * compliance with the License. Please obtain a copy of the License at
+ * http://opensource.org/licenses/Apache-2.0/ and read it before using this
+ * file.
+ *
+ * The Original Code and all software distributed under the License are
+ * distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+ * EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+ * INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+ * Please see the License for the specific language governing rights and
+ * limitations under the License.
+ *
+ * @APPPLANT_LICENSE_HEADER_END@
+ */
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile 'me.leolin:ShortcutBadger:1.1.4@aar'
+}

--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -4,8 +4,8 @@ import android.app.NotificationManager;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.util.Log;
 
+import android.util.Log;
 import com.google.android.gms.gcm.GcmPubSub;
 import com.google.android.gms.iid.InstanceID;
 


### PR DESCRIPTION
Update android shortcut badge even when app is closed (on supported devices - HTC, LG, Samsung)

## Description
Adding android shortcut badges support. Similarly to the [cordova-plugin-badge](https://github.com/katzer/cordova-plugin-badge) behaviour, only it works even when the app is closed, and updated from the Java, not the js. 

## Related Issue
["Notification" Event Not Firing When Closed Through App Launcher](https://github.com/phonegap/phonegap-plugin-push/issues/158)
[Android badge count](https://github.com/phonegap/phonegap-plugin-push/issues/622)

## Motivation and Context
Most major Android Launchers now support badges, which are a useful way to keep users engaged with one's app, specially when users are not visiting it too often. However, in the current situation, badges are only updated when the app is either in the foreground/background, which is usually not the case (Specially if your app is a "twice a week kind" of app)

## How Has This Been Tested?
It has been tested on Samsung galaxy S5, HTC X9, and One Plus (which doesnt support badges, we tested to make sure nothing breaks in that case)

## Screenshots (if appropriate):


## Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
