### PR TITLE
New name for Android Support Repository

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -59,7 +59,7 @@ As of version 1.3.0 the plugin has been switched to using Gradle/Maven for build
 You will need to ensure that you have installed the following items through the Android SDK Manager:
 
 - Android Support Library version 23 or greater
-- Android Support Repository version 20 or greater
+- Local Maven repository for Support Libraries version 20 or greater
 - Google Play Services version 27 or greater
 - Google Repository version 22 or greater
 


### PR DESCRIPTION
## Description
Update the name of Android Support Repository in the docs. It's been changed to Local Maven Repository for Support Libraries in the Android SDK.

## Related Issue

#763 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I followed the INSTALLATION steps and was not able to build because the dependency listed is no longer int he Android SDK. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I installed the new package and compiled my app successfully. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation only. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.

Android Support Repository has been renamed to Local Maven repository for Support Libraries in the Android SDK. 
This commit updates the docs to reflect that fact.