### PR TITLE
Update INSTALLATION.md

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -50,6 +50,14 @@ Where the `XXXXXXX` in `SENDER_ID="XXXXXXX"` maps to the project number in the G
   ]
 ```
 
+> Note: You need to specify the SENDER_ID variable in your config.xml if you plan on installing/restoring plugins using the prepare method.  The prepare method will skip installing the plugin otherwise.
+
+```
+<plugin name="phonegap-plugin-push" spec="1.6.0">
+    <variable name="SENDER_ID" value="XXXXXXX" />
+</plugin>
+```
+
 ## Android details
 
 ### Compilation


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Update of installation instructions to account for installing plugins via the `phonegap prepare` method.

## Motivation and Context
Adding this plugin to the config.xml file using the `--save` argument omits the variable.  The CLI silently skip installing the plugin using `phonegap prepare` unless the SENDER_ID variable is also defined in the config.xml file.  