### PR TITLE
FIXED: iOS app does not show PUSH notifications if the app is in back…

### DIFF
--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -195,6 +195,9 @@ static char coldstartKey;
     }
 }
 
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo {
+    NSLog(@"application:didReceiveRemoteNotification: %@", userInfo);
+}
 
 - (void)application:(UIApplication *) application handleActionWithIdentifier: (NSString *) identifier
 forRemoteNotification: (NSDictionary *) notification completionHandler: (void (^)()) completionHandler {


### PR DESCRIPTION
## Description
This PR fixes a bug when the iOS app is in background or closed, in those situations the app does not show the PUSH notifications.

## Related Issue
Issue: https://github.com/phonegap/phonegap-plugin-push/issues/899

## Motivation and Context
This PR fixes a bug when the iOS app is in background or closed, in those situations the app does not show the PUSH notifications.

## How Has This Been Tested?
Creating a new iOS app and sending PUSH notifications for all the states of the application:
- App in foreground
- App in background
- App closed

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
