### PR TITLE
Add APNs environment information

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -148,6 +148,9 @@ The event `registration` will be triggered on each successful registration with 
 Parameter | Type | Description
 --------- | ---- | -----------
 `data.registrationId` | `string` | The registration ID provided by the 3rd party remote push service.
+`data.apsEnvironment` | `string` | (iOS only): the `aps-environement` entitlement in the `embedded.mobileProvision` file included in the app's bundle. Values can be `development` (sandbox) or `production`. You can pass this to your back-end server together with the registrationID to identify the environment (certificate, key, host) to use.
+`data.apsIsProduction` | `boolean` | (iOS only): `true` if `data.apsEnvironment` is `production`.
+`data.apsIsDevelopment` | `boolean` | (iOS only): `true` if `data.apsEnvironment` is `development`.
 
 ### Example
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -100,7 +100,9 @@ var push = PushNotification.init({
 });
 ```
 
-## PushNotification.hasPermission(successHandler)
+## PushNotification.hasPermission(successHandler) - Android & iOS only
+
+> Deprecated this method will be remove in release 2.0.0
 
 Checks whether the push notification permission has been granted.
 

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -559,11 +559,11 @@
     // Retrieve APNS environment (sandbox or production)
     NSDictionary *mobileProvision = [self getMobileProvision];
     if (mobileProvision) {
-	NSDictionary *entitlements = mobileprovision[@"Entitlements"];
+	NSDictionary *entitlements = mobileProvision[@"Entitlements"];
 	NSString *apsEnvironment = entitlements[@"aps-environment"];
 	message[@"apsEnvironment"] = apsEnvironment;
-	message[@"apsIsProduction"] = entitlements && apsEnvironment && [apsEnvironment isEqualToString:@"production"];
-	message[@"apsIsDevelopment"] = entitlements && apsEnvironment && [apsEnvironment isEqualToString:@"development"];
+	message[@"apsIsProduction"] = @(entitlements && apsEnvironment && [apsEnvironment isEqualToString:@"production"]);
+	message[@"apsIsDevelopment"] = @(entitlements && apsEnvironment && [apsEnvironment isEqualToString:@"development"]);
     }
 
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:message];
@@ -626,17 +626,17 @@
 	if (!provisioningPath) {
 		return nil;
 	}
-	NSData *data = [NSData dataWithContentsOfFile:provisioningPath error:error];
+	NSData *data = [NSData dataWithContentsOfFile:provisioningPath];
 	if (!data) {
-		NSLog(@"error reading embedded %@: %@", provisioningPath, error);
+		NSLog(@"error reading %@", provisioningPath);
 		return nil;
 	}
-	NSRange startRange = [data rangeOfData:[NSData dataWithBytes:"<plist" length: 6] options:0 searchRange:NSMakeRange(0,data.length)];
+	NSRange startRange = [data rangeOfData:[NSData dataWithBytes:"<plist" length: 6] options:0 range:NSMakeRange(0,data.length)];
 	if (startRange.location == NSNotFound) {
 		NSLog(@"unable to find beginning of plist");
 		return nil;
 	}
-	NSRange endRange = [data rangeOfData:[NSData dataWithBytes:"</plist>" length: 8] options:0 searchRange:NSMakeRange(startRange.location,data.length - startRange.location)];
+	NSRange endRange = [data rangeOfData:[NSData dataWithBytes:"</plist>" length: 8] options:0 range:NSMakeRange(startRange.location,data.length - startRange.location)];
 	if (endRange.location == NSNotFound) {
 		NSLog(@"unable to find end of plist");
 		return nil;


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

```
Read the embedded.mobileprovision file and retrieve the
'aps-environement' entitlement to determine whether we're using the
development (sandbox) environment or the production environment.

Add "apsEnvironment" (string), "apsIsProduction" (boolean), and
"apsIsDevelopment"  (boolean)keys to the object passed to the
"registration" event handler.

One can then pass the information to the backend server to use the
correct environment (certificate, key, host).
```

Updated documentation.
## Motivation and Context

To send pushes through APNs, one needs the token but also the environment. The current implementation only returns the former, this change adds the latter.
## How Has This Been Tested?

Tested in iOS app on iOS 9.3.2.
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
