### PR TITLE
Fixed empty token on android first run

### DIFF
--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -51,7 +51,7 @@ public interface PushConstants {
     public static final String FROM = "from";
     public static final String COLLAPSE_KEY = "collapse_key";
     public static final String FORCE_SHOW = "forceShow";
-    public static final String GCM = "GCM";
+    public static final String FCM = "FCM";
     public static final String CONTENT_AVAILABLE = "content-available";
     public static final String TOPICS = "topics";
     public static final String SET_APPLICATION_ICON_BADGE_NUMBER = "setApplicationIconBadgeNumber";

--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -69,6 +69,10 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
 
                         token = FirebaseInstanceId.getInstance().getToken();
 
+                        if (token == null) {
+                            token = FirebaseInstanceId.getInstance().getToken(senderID,FCM);
+                        }
+
                         if (!"".equals(token)) {
                             JSONObject json = new JSONObject().put(REGISTRATION_ID, token);
 
@@ -84,6 +88,9 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
                         }
                     } catch (JSONException e) {
                         Log.e(LOG_TAG, "execute: Got JSON Exception " + e.getMessage());
+                        callbackContext.error(e.getMessage());
+                    } catch (IOException e) {
+                        Log.e(LOG_TAG, "execute: Got IO Exception " + e.getMessage());
                         callbackContext.error(e.getMessage());
                     }
 


### PR DESCRIPTION
## Description
Fixed empty token on android first run

## Related Issue
https://github.com/phonegap/phonegap-plugin-push/issues/929

## Motivation and Context
On fisrt run the token is empty, this forces to get the token fixing the problem


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

