### PR TITLE
Implemented clearBadge for Android

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -42,6 +42,7 @@ Attribute | Type | Default | Description
 `android.iconColor` | `string` | | Optional. Sets the background color of the small icon on Android 5.0 and greater. [Supported Formats](http://developer.android.com/reference/android/graphics/Color.html#parseColor(java.lang.String))
 `android.sound` | `boolean` | `true` | Optional. If `true` it plays the sound specified in the push data or the default system sound.
 `android.vibrate` | `boolean` | `true` | Optional. If `true` the device vibrates on receipt of notification.
+`android.clearBadge` | `boolean` | `true` | Optional. If `true` the icon badge will be cleared on init and before push messages are processed.
 `android.clearNotifications` | `boolean` | `true` | Optional. If `true` the app clears all pending notifications when it is closed.
 `android.forceShow` | `boolean` | `false` | Optional. Controls the behavior of the notification when app is in foreground. If `true` and app is in foreground, it will show a notification in the notification drawer, the same way as when the app is in background (and `on('notification')` callback will be called *only when the user clicks the notification*). When `false` and app is in foreground, the `on('notification')` callback will be called immediately.
 `android.topics` | `array` | `[]` | Optional. If the array contains one or more strings each string will be used to subscribe to a GcmPubSub topic.

--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -65,8 +65,13 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
 
             SharedPreferences prefs = getApplicationContext().getSharedPreferences(PushPlugin.COM_ADOBE_PHONEGAP_PUSH, Context.MODE_PRIVATE);
             boolean forceShow = prefs.getBoolean(FORCE_SHOW, false);
+            boolean clearBadge = prefs.getBoolean(CLEAR_BADGE, false);
 
             extras = normalizeExtras(extras);
+
+            if (clearBadge) {
+                PushPlugin.setApplicationIconBadgeNumber(getApplicationContext(), 0);
+            }
 
             // if we are in the foreground and forceShow is `false` only send data
             if (!forceShow && PushPlugin.isInForeground()) {

--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -44,6 +44,7 @@ public interface PushConstants {
     public static final String HAS_PERMISSION = "hasPermission";
     public static final String ANDROID = "android";
     public static final String SENDER_ID = "senderID";
+    public static final String CLEAR_BADGE = "clearBadge";
     public static final String CLEAR_NOTIFICATIONS = "clearNotifications";
     public static final String COLDSTART = "coldstart";
     public static final String ADDITIONAL_DATA = "additionalData";

--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -116,7 +116,12 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
                         } catch (JSONException e) {
                             Log.d(LOG_TAG, "no iconColor option");
                         }
+                        
                         boolean clearBadge = jo.optBoolean(CLEAR_BADGE, false);
+                        if (clearBadge) {
+                            setApplicationIconBadgeNumber(getApplicationContext(), 0);
+                        }
+
                         editor.putBoolean(SOUND, jo.optBoolean(SOUND, true));
                         editor.putBoolean(VIBRATE, jo.optBoolean(VIBRATE, true));
                         editor.putBoolean(CLEAR_BADGE, clearBadge);
@@ -126,9 +131,6 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
                         editor.putString(REGISTRATION_ID, token);
                         editor.commit();
 
-                        if (clearBadge) {
-                            setApplicationIconBadgeNumber(getApplicationContext(), 0);
-                        }
                     }
 
                     if (gCachedExtras != null) {

--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -116,13 +116,19 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
                         } catch (JSONException e) {
                             Log.d(LOG_TAG, "no iconColor option");
                         }
+                        boolean clearBadge = jo.optBoolean(CLEAR_BADGE, false);
                         editor.putBoolean(SOUND, jo.optBoolean(SOUND, true));
                         editor.putBoolean(VIBRATE, jo.optBoolean(VIBRATE, true));
+                        editor.putBoolean(CLEAR_BADGE, clearBadge);
                         editor.putBoolean(CLEAR_NOTIFICATIONS, jo.optBoolean(CLEAR_NOTIFICATIONS, true));
                         editor.putBoolean(FORCE_SHOW, jo.optBoolean(FORCE_SHOW, false));
                         editor.putString(SENDER_ID, senderID);
                         editor.putString(REGISTRATION_ID, token);
                         editor.commit();
+
+                        if (clearBadge) {
+                            setApplicationIconBadgeNumber(getApplicationContext(), 0);
+                        }
                     }
 
                     if (gCachedExtras != null) {
@@ -149,6 +155,7 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
                             SharedPreferences.Editor editor = sharedPref.edit();
                             editor.remove(SOUND);
                             editor.remove(VIBRATE);
+                            editor.remove(CLEAR_BADGE);
                             editor.remove(CLEAR_NOTIFICATIONS);
                             editor.remove(FORCE_SHOW);
                             editor.remove(SENDER_ID);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I added the init parameter "clearBadge" which is treated the same as the others and stored to SharedPreferences. If it's set, the app sets the badge number to 0 on init. Also, when a notification is receviced, the badge number is immediately cleared in order to leave the config of the badge through notification parameter untouched. Now when a notification is recevied, the badge is cleared before the notification content is processed, therefore any badge numbers set in the notification will be respected. I tried to implement this as close to the iOS implementation as possible.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/phonegap/phonegap-plugin-push/issues/999

## Motivation and Context
Even though I was not setting the Badge Number, it was some times (on specific devices) appearing out of nowhere after init. I wanted to have a way to make sure that the Badge Number is not shown by accident.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I manually added a badge number through the "setApplicationBadgeNumber" function. Then I restarted the app causing the init function to trigger. The badge number was immediately cleared. I also set the BadgeNumber after init and sent a notification that had no badge number arguments. The badge number was also cleared immediately.

<!--- Include details of your testing environment, and the tests you ran to -->
I only did manual tests on Android devices.
<!--- see how your change affects other areas of the code, etc. -->
There shouldn't be any unexpected side effects on other code.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

