### PR TITLE
Fix GCM dependency

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -86,7 +86,7 @@
 
         <framework src="push.gradle" custom="true" type="gradleReference" />
         <framework src="com.android.support:support-v13:23+" />
-        <framework src="com.google.android.gms:play-services-gcm:+" />
+        <framework src="com.google.android.gms:play-services-gcm:9.0.2" />
         <framework src="me.leolin:ShortcutBadger:1.1.4@aar" />
 
 		<source-file src="src/android/com/adobe/phonegap/push/GCMIntentService.java" target-dir="src/com/adobe/phonegap/push/" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -86,7 +86,7 @@
 
         <framework src="push.gradle" custom="true" type="gradleReference" />
         <framework src="com.android.support:support-v13:23+" />
-        <framework src="com.google.android.gms:play-services-gcm:9.0.2" />
+        <framework src="com.google.android.gms:play-services-gcm:9.0.2+" />
         <framework src="me.leolin:ShortcutBadger:1.1.4@aar" />
 
 		<source-file src="src/android/com/adobe/phonegap/push/GCMIntentService.java" target-dir="src/com/adobe/phonegap/push/" />


### PR DESCRIPTION
Changed GCM dependency

## Description
Use a fixed GCM version to prevent build errors which occurs with the latest GCM artifacts, when this plugin is used together with other plugins which uses GCM.

## Motivation and Context
When this plugin is used together with `cordova-plugin-googleplus` it produces the following error while building:
```
UNEXPECTED TOP-LEVEL EXCEPTION:
com.android.dex.DexException: Multiple dex files define Lcom/google/android/gms/internal/zzsk$zza;
	at com.android.dx.merge.DexMerger.readSortableTypes(DexMerger.java:579)
	at com.android.dx.merge.DexMerger.getSortedTypes(DexMerger.java:535)
	at com.android.dx.merge.DexMerger.mergeClassDefs(DexMerger.java:517)
	at com.android.dx.merge.DexMerger.mergeDexes(DexMerger.java:164)
	at com.android.dx.merge.DexMerger.merge(DexMerger.java:188)
	at com.android.dx.command.dexer.Main.mergeLibraryDexBuffers(Main.java:504)
	at com.android.dx.command.dexer.Main.runMonoDex(Main.java:334)
	at com.android.dx.command.dexer.Main.run(Main.java:277)
	at com.android.dx.command.dexer.Main.main(Main.java:245)
	at com.android.dx.command.Main.main(Main.java:106)
```

## How Has This Been Tested?
By compiling [Rocket.Chat.Cordova](https://github.com/RocketChat/Rocket.Chat.Cordova).
Check also [this issue comment](https://github.com/RocketChat/Rocket.Chat.Cordova/issues/118#issuecomment-230415907)