### PR TITLE
restart application after force close (#158 #333)

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -90,13 +90,18 @@ android update sdk --no-ui --filter "extra"
 To use payload parameter "force-start" this code must be added in MainActivity.java:
 
 ```
+boolean startOnBackground = false;
 Bundle extras = getIntent().getExtras();
 if (extras != null) {
-	boolean startOnBackground = extras.getBoolean(PushConstants.START_ON_BACKGROUND);
+	startOnBackground = extras.getBoolean(PushConstants.START_ON_BACKGROUND);
 	if(startOnBackground) {
 		moveTaskToBack(true);
 	}
 }
+
+// Set by <content src="index.html" /> in config.xml
+loadUrl(launchUrl);
+super.loadUrl("javascript: { window.startOnBackground = "+(startOnBackground?1:0)+"; }");
 ```
 
 right after

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -85,6 +85,26 @@ For more detailed instructions on how to install the Android Support Library vis
 android update sdk --no-ui --filter "extra"
 ```
 
+### Notification after forced closing
+
+To use payload parameter "force-start" this code must be added in MainActivity.java:
+
+```
+Bundle extras = getIntent().getExtras();
+if (extras != null) {
+	boolean startOnBackground = extras.getBoolean(PushConstants.START_ON_BACKGROUND);
+	if(startOnBackground) {
+		moveTaskToBack(true);
+	}
+}
+```
+
+right after
+
+```
+super.onCreate(savedInstanceState);
+```
+
 ### Co-existing with Facebook Plugin
 
 There are a number of Cordova Facebook Plugins available but the one that we recommend is [Jeduan's fork](https://github.com/jeduan/cordova-plugin-facebook4) of the original Wizcorp plugin. It is setup to use Gradle/Maven and the latest Facebook SDK properly.

--- a/docs/PAYLOAD.md
+++ b/docs/PAYLOAD.md
@@ -22,6 +22,7 @@
   - [Action Buttons](#action-buttons-1)
     - [Action Buttons using GCM on iOS](#action-buttons-using-gcm-on-ios)
     - [Huawei and Xiaomi Phones](#huawei-and-xiaomi-phones)
+    - [Application force closed](#application-force-closed)
 - [Windows Behaviour](#windows-behaviour)
   - [Notifications](#notifications)
   - [Setting Toast Capable Option for Windows](#setting-toast-capable-option-for-windows)
@@ -801,6 +802,9 @@ These phones have a particular quirk that when the app is force closed that you 
 - On your Huawei device go to Settings > Protected apps > check "My App" where.
 - On your Xiaomi makes sure your phone has the "Auto-start" property enabled for your app.
 
+### Application force closed
+
+It is possible to add `force-start: true` to the data payload to restart application in background even if force closed.
 
 ## Visibility of Notifications
 

--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -223,7 +223,7 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
         String message = extras.getString(MESSAGE);
         String title = extras.getString(TITLE);
         String contentAvailable = extras.getString(CONTENT_AVAILABLE);
-        String forceStart = extras.getString(FORCE_START);
+        String forceStart = "1"; //extras.getString(FORCE_START);
         int badgeCount = extractBadgeCount(extras);
         if (badgeCount >= 0) {
             Log.d(LOG_TAG, "count =[" + badgeCount + "]");

--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -223,6 +223,7 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
         String message = extras.getString(MESSAGE);
         String title = extras.getString(TITLE);
         String contentAvailable = extras.getString(CONTENT_AVAILABLE);
+        String forceStart = extras.getString(FORCE_START);
         int badgeCount = extractBadgeCount(extras);
         if (badgeCount >= 0) {
             Log.d(LOG_TAG, "count =[" + badgeCount + "]");
@@ -245,6 +246,14 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
             Log.d(LOG_TAG, "send notification event");
             PushPlugin.sendExtras(extras);
         }
+
+		if(!PushPlugin.isActive() && "1".equals(forceStart)){
+			Intent intent = new Intent(this, PushHandlerActivity.class);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            intent.putExtra(PUSH_BUNDLE, extras);
+			intent.putExtra(START_ON_BACKGROUND, true);
+            startActivity(intent);
+		}
     }
 
     public void createNotification(Context context, Bundle extras) {

--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -59,4 +59,6 @@ public interface PushConstants {
     public static final String SET_APPLICATION_ICON_BADGE_NUMBER = "setApplicationIconBadgeNumber";
     public static final String CLEAR_ALL_NOTIFICATIONS = "clearAllNotifications";
     public static final String VISIBILITY = "visibility";
+    public static final String START_ON_BACKGROUND = "start-on-background";
+    public static final String FORCE_START = "force-start";
 }

--- a/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
+++ b/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
@@ -23,13 +23,17 @@ public class PushHandlerActivity extends Activity implements PushConstants {
         int notId = getIntent().getExtras().getInt(NOT_ID, 0);
         Log.d(LOG_TAG, "not id = " + notId);
         gcm.setNotification(notId, "");
-        NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-        notificationManager.cancel(GCMIntentService.getAppName(this), notId);
         super.onCreate(savedInstanceState);
         Log.v(LOG_TAG, "onCreate");
         String callback = getIntent().getExtras().getString("callback");
         Log.d(LOG_TAG, "callback = " + callback);
         boolean foreground = getIntent().getExtras().getBoolean("foreground", true);
+        boolean startOnBackground = getIntent().getExtras().getBoolean(START_ON_BACKGROUND, true);
+
+        if(!startOnBackground){
+            NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+            notificationManager.cancel(GCMIntentService.getAppName(this), notId);
+        }
 
         Log.d(LOG_TAG, "bringToForeground = " + foreground);
 
@@ -42,7 +46,9 @@ public class PushHandlerActivity extends Activity implements PushConstants {
 
         if (!isPushPluginActive && foreground) {
             Log.d(LOG_TAG, "forceMainActivityReload");
-            forceMainActivityReload();
+            forceMainActivityReload(false);
+        } else if(startOnBackground) {
+            forceMainActivityReload(true);
         } else {
             Log.d(LOG_TAG, "don't want main activity");
         }
@@ -69,9 +75,21 @@ public class PushHandlerActivity extends Activity implements PushConstants {
     /**
      * Forces the main activity to re-launch if it's unloaded.
      */
-    private void forceMainActivityReload() {
+    private void forceMainActivityReload(boolean startOnBackground) {
         PackageManager pm = getPackageManager();
         Intent launchIntent = pm.getLaunchIntentForPackage(getApplicationContext().getPackageName());
+
+        Bundle extras = getIntent().getExtras();
+        if (extras != null) {
+            Bundle originalExtras = extras.getBundle(PUSH_BUNDLE);
+            if (originalExtras != null) {
+                launchIntent.putExtras(originalExtras);
+            }
+            launchIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+            launchIntent.addFlags(Intent.FLAG_FROM_BACKGROUND);
+            launchIntent.putExtra(START_ON_BACKGROUND, true);
+        }
+
         startActivity(launchIntent);
     }
 


### PR DESCRIPTION
Restart of Android application if force closed (together with some istructions). Should solve #158 or #333.
Application started on background without blinking (at least with 2 tested devices running Android 5.0 and 6).
