### PR TITLE
Added hook and resource file to copy GoogleService-Info.plist

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -118,6 +118,7 @@
         <framework src="src/ios/Firebase/Analytics/GoogleUtilities.framework" custom="true" />
         <framework src="src/ios/Firebase/Messaging/FirebaseMessaging.framework" custom="true" />
         <framework src="src/ios/Firebase/Messaging/GoogleIPhoneUtilities.framework" custom="true" />
+        <resource-file src="src/ios/Firebase/GoogleService-Info.plist" target="Resources/GoogleService-Info.plist" />
         <!--  End FCM Related Files -->
 	</platform>
 
@@ -130,5 +131,7 @@
     		<preference name="WindowsToastCapable" value="true" />
     	</config-file>
 	</platform>
+
+    <hook src="scripts/copy_file.js" type="after_prepare" />
 
 </plugin>

--- a/scripts/copy_file.js
+++ b/scripts/copy_file.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+'use strict';
+
+var fs = require('fs');
+
+var getValue = function(config, name) {
+    var value = config.match(new RegExp('<' + name + '>(.*?)</' + name + '>', "i"))
+    if(value && value[1]) {
+        return value[1]
+    } else {
+        return null
+    }
+}
+
+function fileExists(path) {
+  try  {
+    return fs.statSync(path).isFile();
+  }
+  catch (e) {
+    return false;
+  }
+}
+
+function directoryExists(path) {
+  try  {
+    return fs.statSync(path).isDirectory();
+  }
+  catch (e) {
+    return false;
+  }
+}
+
+var config = fs.readFileSync("config.xml").toString();
+var name = getValue(config, "name");
+
+if(fileExists("GoogleService-Info.plist") && directoryExists("platforms/ios/")){
+  try {
+  	var contents = fs.readFileSync("GoogleService-Info.plist").toString();
+    fs.writeFileSync("platforms/ios/" + name + "/Resources/GoogleService-Info.plist", contents);
+  } catch(err) {
+    process.stdout.write(err);
+  }
+}

--- a/src/ios/Firebase/GoogleService-Info.plist
+++ b/src/ios/Firebase/GoogleService-Info.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>


### PR DESCRIPTION
Added a GoogleService-Info.plist resource file (empty) and a hook that copies the content of your GoogleService-Info.plist on the root of the project to the empty one on cordova prepare