### PR TITLE
added Azure server-side example

### DIFF
--- a/example/server/pushAzure.js
+++ b/example/server/pushAzure.js
@@ -1,7 +1,3 @@
-// ----------------------------------------------------------------------------
-// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
-// ----------------------------------------------------------------------------
-
 /*
 ** Sample Table Definition - this supports the Azure Mobile Apps
 ** TodoItem product
@@ -17,7 +13,7 @@ var table = azureMobileApps.table();
 // In the TodoItem product, sends a push notification
 // when a new item inserted into the table.
 table.insert(function (context) {
-    // For more information about the Notification Hubs JavaScript SDK, 
+    // For more information about the Notification Hubs JavaScript SDK,
     // see http://aka.ms/nodejshubs
     logger.info('Running TodoItem.insert');
 

--- a/example/server/pushAzure.js
+++ b/example/server/pushAzure.js
@@ -1,0 +1,52 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+/*
+** Sample Table Definition - this supports the Azure Mobile Apps
+** TodoItem product
+** https://azure.microsoft.com/en-us/documentation/articles/app-service-mobile-cordova-get-started/
+*/
+var azureMobileApps = require('azure-mobile-apps'),
+promises = require('azure-mobile-apps/src/utilities/promises'),
+logger = require('azure-mobile-apps/src/logger');
+
+// Create a new table definition
+var table = azureMobileApps.table();
+
+// In the TodoItem product, sends a push notification
+// when a new item inserted into the table.
+table.insert(function (context) {
+    // For more information about the Notification Hubs JavaScript SDK, 
+    // see http://aka.ms/nodejshubs
+    logger.info('Running TodoItem.insert');
+
+    // Define the push notification template payload.
+    // Requires template specified in the client app. See
+    // https://azure.microsoft.com/en-us/documentation/articles/app-service-mobile-cordova-get-started-push/
+    var payload = '{"message": "' + context.item.text + '" }';
+
+    // Execute the insert.  The insert returns the results as a Promise,
+    // Do the push as a post-execute action within the promise flow.
+    return context.execute()
+        .then(function (results) {
+            // Only do the push if configured
+            if (context.push) {
+
+                context.push.send(null, payload, function (error) {
+                    if (error) {
+                        logger.error('Error while sending push notification: ', error);
+                    } else {
+                        logger.info('Push notification sent successfully!');
+                    }
+                });
+            }
+            // Don't forget to return the results from the context.execute()
+            return results;
+        })
+        .catch(function (error) {
+            logger.error('Error while running context.execute: ', error);
+        });
+});
+
+module.exports = table;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added an example of doing push in a node.js backend from Azure using an 
Azure Mobile App, push notification hubs, and push notification templates.

## Related Issue

## Motivation and Context
There are various examples of using the plugin server-side such as ADM, but none for Azure.

## How Has This Been Tested?
This has been tested in Cordova apps against Android, iOS, and Windows. It is the same code found in the official Azure documentation here:
https://azure.microsoft.com/en-us/documentation/articles/app-service-mobile-cordova-get-started-push/#add-push-to-app

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

