### PR TITLE
[Windows] Added a check on activation context existence

### DIFF
--- a/src/windows/PushPluginProxy.js
+++ b/src/windows/PushPluginProxy.js
@@ -66,13 +66,13 @@ module.exports = {
                     onSuccess(result, { keepCallback: true });
 
                     var context = cordova.require('cordova/platform').activationContext;
-                    var launchArgs = context.args;
+                    var launchArgs = context ? context.args : null;
                     if (launchArgs) {         //If present, app launched through push notification
                         var result = { message: '' };       //Added to identify callback as notification type in the API
                         result.launchArgs = launchArgs;
                         result.additionalData = { coldstart: true };
                         onSuccess(result, { keepCallback: true });
-                    } 
+                    }
                 }, function (error) {
                     onFail(error);
                 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a check on existence of the activation context when determining if the app was launched by a push notification as it was crashing when the context was not defined.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/phonegap/phonegap-plugin-push/issues/1036

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The activation context (`cordova.require('cordova/platform').activationContext`) is not guaranteed to exist, the block depending on it is not necessary for the core functionality to work so there's no reason to let it fail with `Unable to get property 'args' of undefined or null reference` error.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on physical devices (smartphones) with Windows 10 & WindowsPhone 8.1

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

