### PR TITLE
Update appxmanifests with ToastCapable=true after plugin install

### DIFF
--- a/hooks/windows/setToastCapable.js
+++ b/hooks/windows/setToastCapable.js
@@ -1,0 +1,12 @@
+module.exports = function(context) {
+    console.log('Updating appxmanifests with ToastCapable=true...');
+    var path = require('path');
+    var platformProjPath = path.join(context.opts.projectRoot, 'platforms/windows');
+    var AppxManifest = require(path.join(platformProjPath, 'cordova/lib/AppxManifest'));
+
+    ['package.phone.appxmanifest', 'package.windows.appxmanifest'].forEach(function(manifestPath) {
+        var manifest = AppxManifest.get(path.join(platformProjPath, manifestPath));
+        manifest.getVisualElements().setToastCapable(true);
+        manifest.write();
+    });
+}

--- a/plugin.xml
+++ b/plugin.xml
@@ -143,6 +143,7 @@
     <framework src="libz.tbd"/>
   </platform>
   <platform name="windows">
+    <hook type="after_plugin_install" src="hooks/windows/setToastCapable.js"/>
     <js-module src="src/windows/PushPluginProxy.js" name="PushPlugin">
       <merges target=""/>
     </js-module>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update appxmanifests with ToastCapable=true after plugin install

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/phonegap/phonegap-plugin-push/issues/1033

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`ToastCapable` is not being set on plugin add - only after `prepare`, which might not occur in VS-centered scenario.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with CLI and VS TACO Tools.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

