### PR TITLE
Use unique pending intent request code to enable multiple simultaneou…

### DIFF
--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -379,6 +379,7 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
                 JSONArray actionsArray = new JSONArray(actions);
                 ArrayList<NotificationCompat.Action> wActions = new ArrayList<NotificationCompat.Action>();
                 for (int i=0; i < actionsArray.length(); i++) {
+                    int uniquePendingIntentRequestCode = i + notId;
                     Log.d(LOG_TAG, "adding action");
                     JSONObject action = actionsArray.getJSONObject(i);
                     Log.d(LOG_TAG, "adding callback = " + action.getString(CALLBACK));
@@ -399,20 +400,20 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
                         updateIntent(intent, action.getString(CALLBACK), extras, foreground, notId);
 
                         if (android.os.Build.VERSION.SDK_INT <= android.os.Build.VERSION_CODES.M) {
-                            Log.d(LOG_TAG, "push activity");
-                            pIntent = PendingIntent.getActivity(this, i, intent, PendingIntent.FLAG_ONE_SHOT);
+                            Log.d(LOG_TAG, "push activity for notId " + notId);
+                            pIntent = PendingIntent.getActivity(this, uniquePendingIntentRequestCode, intent, PendingIntent.FLAG_ONE_SHOT);
                         } else {
-                            Log.d(LOG_TAG, "push receiver");
-                            pIntent = PendingIntent.getBroadcast(this, i, intent, PendingIntent.FLAG_ONE_SHOT);
+                            Log.d(LOG_TAG, "push receiver for notId " + notId);
+                            pIntent = PendingIntent.getBroadcast(this, uniquePendingIntentRequestCode, intent, PendingIntent.FLAG_ONE_SHOT);
                         }
                     } else if (foreground) {
                         intent = new Intent(this, PushHandlerActivity.class);
                         updateIntent(intent, action.getString(CALLBACK), extras, foreground, notId);
-                        pIntent = PendingIntent.getActivity(this, i, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+                        pIntent = PendingIntent.getActivity(this, uniquePendingIntentRequestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT);
                     } else {
                         intent = new Intent(this, BackgroundActionButtonHandler.class);
                         updateIntent(intent, action.getString(CALLBACK), extras, foreground, notId);
-                        pIntent = PendingIntent.getBroadcast(this, i, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+                        pIntent = PendingIntent.getBroadcast(this, uniquePendingIntentRequestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT);
                     }
 
                     NotificationCompat.Action.Builder actionBuilder =


### PR DESCRIPTION
…s notifications with action buttons

## Description
Use a unique pending intent id for each action button for each Android notification (instead of 0, 1, 2 for all notifications). 

## Related Issue
https://github.com/phonegap/phonegap-plugin-push/issues/1215

## Motivation and Context
This allows for multiple simultaneous notifications with action buttons.  Previously, all buttons were linked to the most recently created notification. 

## How Has This Been Tested?
Manually and with `npm test`.

## Screenshots (if appropriate):

## Types of changes
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. (I don't really see any Android specific tests)
- [X] All new and existing tests passed.