### PR TITLE
Add features: push.subscribe, push.unsubscribe (issue #1040)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -8,6 +8,8 @@
   - [push.on('error')](#pushonerror-callback)
 - [push.off()](#pushoffevent-callback)
 - [push.unregister()](#pushunregistersuccesshandler-errorhandler-topics)
+- [push.subscribe()](#pushsubscribetopic-successhandler-errorhandler)
+- [push.unsubscribe()](#pushunsubscribetopic-successhandler-errorhandler)
 - [push.setApplicationIconBadgeNumber() - iOS & Android only](#pushsetapplicationiconbadgenumbersuccesshandler-errorhandler-count---ios--android-only)
 - [push.getApplicationIconBadgeNumber() - iOS only](#pushgetapplicationiconbadgenumbersuccesshandler-errorhandler---ios-only)
 - [push.finish() - iOS only](#pushfinishsuccesshandler-errorhandler-id---ios-only)
@@ -278,6 +280,51 @@ push.unregister(function() {
 	console.log('success');
 }, function() {
 	console.log('error');
+});
+```
+
+## push.subscribe(topic, successHandler, errorHandler)
+
+The subscribe method is used when the application wants to subscribe a new topic to receive push notifications.
+
+### Parameters
+
+Parameter | Type | Default | Description
+--------- | ---- | ------- | -----------
+`topic` | `String` | | Topic to subscribe to.
+`successHandler` | `Function` | | Is called when the api successfully subscribes.
+`errorHandler` | `Function` | | Is called when the api encounters an error while subscribing.
+
+### Example
+
+```javascript
+push.subscribe('my-topic', function() {
+	console.log('success');
+}, function(e) {
+	console.log('error:');
+	console.log(e);
+});
+```
+## push.unsubscribe(topic, successHandler, errorHandler)
+
+The unsubscribe method is used when the application no longer wants to receive push notifications from a specific topic but continue to receive other push messages.
+
+### Parameters
+
+Parameter | Type | Default | Description
+--------- | ---- | ------- | -----------
+`topic` | `String` | | Topic to unsubscribe from.
+`successHandler` | `Function` | | Is called when the api successfully unsubscribe.
+`errorHandler` | `Function` | | Is called when the api encounters an error while unsubscribing.
+
+### Example
+
+```javascript
+push.unsubscribe('my-topic', function() {
+	console.log('success');
+}, function(e) {
+	console.log('error:');
+	console.log(e);
 });
 ```
 

--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -39,6 +39,8 @@ public interface PushConstants {
     public static final String STYLE_TEXT = "text";
     public static final String BADGE = "badge";
     public static final String INITIALIZE = "init";
+    public static final String SUBSCRIBE = "subscribe";
+    public static final String UNSUBSCRIBE = "unsubscribe";
     public static final String UNREGISTER = "unregister";
     public static final String EXIT = "exit";
     public static final String FINISH = "finish";

--- a/src/ios/PushPlugin.h
+++ b/src/ios/PushPlugin.h
@@ -55,6 +55,8 @@
 
 - (void)init:(CDVInvokedUrlCommand*)command;
 - (void)unregister:(CDVInvokedUrlCommand*)command;
+- (void)subscribe:(CDVInvokedUrlCommand*)command;
+- (void)unsubscribe:(CDVInvokedUrlCommand*)command;
 
 - (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 - (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -83,7 +83,7 @@
             [weakSelf registerWithToken:registrationToken];
         } else {
             NSLog(@"Registration to GCM failed with error: %@", error.localizedDescription);
-            [weakSelf failWithMessage:@"" withError:error];
+            [weakSelf failWithMessage:self.callbackId withMsg:@"" withError:error];
         }
     };
 }
@@ -124,8 +124,6 @@
 
 - (void)unregister:(CDVInvokedUrlCommand*)command;
 {
-    self.callbackId = command.callbackId;
-
     NSArray* topics = [command argumentAtIndex:0];
 
     if (topics != nil) {
@@ -146,7 +144,63 @@
         }
     } else {
         [[UIApplication sharedApplication] unregisterForRemoteNotifications];
-        [self successWithMessage:@"unregistered"];
+        [self successWithMessage:command.callbackId withMsg:@"unregistered"];
+    }
+}
+
+- (void)subscribe:(CDVInvokedUrlCommand*)command;
+{
+    NSString* topic = [command argumentAtIndex:0];
+
+    if (topic != nil) {
+        NSLog(@"subscribe from topic: %@", topic);
+        id pubSub = [GCMPubSub sharedInstance];
+        [pubSub subscribeWithToken: [self gcmRegistrationToken]
+            topic:[NSString stringWithFormat:@"/topics/%@", topic]
+            options:nil
+            handler:^void(NSError *error) {
+                if (error) {
+                    if (error.code == 3001) {
+                        NSLog(@"Already subscribed to %@", topic);
+                        [self successWithMessage:command.callbackId withMsg:[NSString stringWithFormat:@"Already subscribed to %@", topic]];
+                    } else {
+                        NSLog(@"Failed to subscribe to topic %@: %@", topic, error);
+                        [self failWithMessage:command.callbackId withMsg:[NSString stringWithFormat:@"Failed to subscribe to topic %@", topic] withError:error];
+                    }
+                }
+                else {
+                    NSLog(@"Successfully subscribe to topic %@", topic);
+                    [self successWithMessage:command.callbackId withMsg:[NSString stringWithFormat:@"Successfully subscribe to topic %@", topic]];
+                }
+        }];
+    } else {
+        NSLog(@"There is no topic to subscribe");
+        [self successWithMessage:command.callbackId withMsg:@"There is no topic to subscribe"];
+    }
+}
+
+- (void)unsubscribe:(CDVInvokedUrlCommand*)command;
+{
+    NSString* topic = [command argumentAtIndex:0];
+
+    if (topic != nil) {
+        NSLog(@"unsubscribe from topic: %@", topic);
+        id pubSub = [GCMPubSub sharedInstance];
+        [pubSub unsubscribeWithToken: [self gcmRegistrationToken]
+            topic:[NSString stringWithFormat:@"/topics/%@", topic]
+            options:nil
+            handler:^void(NSError *error) {
+                if (error) {
+                    NSLog(@"Failed to unsubscribe to topic %@: %@", topic, error);
+                    [self failWithMessage:command.callbackId withMsg:[NSString stringWithFormat:@"Failed to unsubscribe to topic %@", topic] withError:error];
+                } else {
+                    NSLog(@"Successfully unsubscribe to topic %@", topic);
+                    [self successWithMessage:command.callbackId withMsg:[NSString stringWithFormat:@"Successfully unsubscribe to topic %@", topic]];
+                }
+        }];
+    } else {
+        NSLog(@"There is no topic to unsubscribe");
+        [self successWithMessage:command.callbackId withMsg:@"There is no topic to unsubscribe"];
     }
 }
 
@@ -435,7 +489,7 @@
         return;
     }
     NSLog(@"Push Plugin register failed");
-    [self failWithMessage:@"" withError:error];
+    [self failWithMessage:self.callbackId withMsg:@"" withError:error];
 }
 
 - (void)notificationReceived {
@@ -555,12 +609,12 @@
     [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
 }
 
--(void)successWithMessage:(NSString *)message
+-(void)successWithMessage:(NSString *)callbackId withMsg:(NSString *)message
 {
-    if (self.callbackId != nil)
+    if (callbackId != nil)
     {
         CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:message];
-        [self.commandDelegate sendPluginResult:commandResult callbackId:self.callbackId];
+        [self.commandDelegate sendPluginResult:commandResult callbackId:callbackId];
     }
 }
 
@@ -574,12 +628,12 @@
 }
 
 
--(void)failWithMessage:(NSString *)message withError:(NSError *)error
+-(void)failWithMessage:(NSString *)callbackId withMsg:(NSString *)message withError:(NSError *)error
 {
     NSString        *errorMessage = (error) ? [NSString stringWithFormat:@"%@ - %@", message, [error localizedDescription]] : message;
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:errorMessage];
 
-    [self.commandDelegate sendPluginResult:commandResult callbackId:self.callbackId];
+    [self.commandDelegate sendPluginResult:commandResult callbackId:callbackId];
 }
 
 -(void) finish:(CDVInvokedUrlCommand*)command

--- a/www/push.js
+++ b/www/push.js
@@ -96,6 +96,52 @@ PushNotification.prototype.unregister = function(successCallback, errorCallback,
 };
 
 /**
+ * subscribe to a topic
+ * @param   {String}      topic               topic to subscribe
+ * @param   {Function}    successCallback     success callback
+ * @param   {Function}    errorCallback       error callback
+ * @return  {void}
+ */
+PushNotification.prototype.subscribe = function(topic, successCallback, errorCallback) {
+    if (!errorCallback) { errorCallback = function() {}; }
+
+    if (typeof errorCallback !== 'function')  {
+        console.log('PushNotification.subscribe failure: failure parameter not a function');
+        return;
+    }
+
+    if (typeof successCallback !== 'function') {
+        console.log('PushNotification.subscribe failure: success callback parameter must be a function');
+        return;
+    }
+
+    exec(successCallback, errorCallback, 'PushNotification', 'subscribe', [topic]);
+};
+
+/**
+ * unsubscribe to a topic
+ * @param   {String}      topic               topic to unsubscribe
+ * @param   {Function}    successCallback     success callback
+ * @param   {Function}    errorCallback       error callback
+ * @return  {void}
+ */
+PushNotification.prototype.unsubscribe = function(topic, successCallback, errorCallback) {
+    if (!errorCallback) { errorCallback = function() {}; }
+
+    if (typeof errorCallback !== 'function')  {
+        console.log('PushNotification.unsubscribe failure: failure parameter not a function');
+        return;
+    }
+
+    if (typeof successCallback !== 'function') {
+        console.log('PushNotification.unsubscribe failure: success callback parameter must be a function');
+        return;
+    }
+
+    exec(successCallback, errorCallback, 'PushNotification', 'unsubscribe', [topic]);
+};
+
+/**
  * Call this to set the application icon badge
  */
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add 2 API: 
+ push.subscribe
+ push.unsubscribe

Refactoring: 
+ Add function: getTopicPath() to normalize topic (from `topic_name` to `topics/topic_name`) , and follow DRY principle (the `getTopicPath` function will be re-used)
+ split `subscribeToTopics` into  `subscribeToTopics` and `subscribeToTopic` to improve reuse ability. 

+ in iOS: failWithMessage(string msg) will be replaced by failWithMessage(callbackId, string msg) => this will improve reuse ability & reducing the error rate in the code. Because in previous code It always use callbackId from push.init(). It's not good and It could cause misleading.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/phonegap/phonegap-plugin-push/issues/1040

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Add more API

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in production environment. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

