### PR TITLE
Add `cordovaDependencies` section to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,18 @@
     "cordova-wp8",
     "cordova-browser"
   ],
-  "engines": [
-    {
-      "name": "cordova",
-      "version": ">=3.0.0"
+  "engines": {
+    "cordovaDependencies": {
+      "1.8.2": {
+        "cordova": ">=3.6.3",
+        "cordova-android": ">=4.0.0",
+        "cordova-ios": ">=4.1.0"
+      },
+      "2.0.0": {
+        "cordova": ">100"
+      }
     }
-  ],
+  },
   "author": "Adobe PhoneGap Team",
   "license": "APL",
   "scripts": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This reflects `engines` elements from plugin manifest to package.json to comply w/ [new plugin fetching model](https://github.com/cordova/cordova-discuss/blob/master/proposals/plugin-version-fetching.md) and corrects `engine`'s value according to [package.json format](https://docs.npmjs.com/files/package.json#engines)

Its also desirable to add 'protective' entry for next major plugin version as per corresponding [discussion on cordova mailing list](http://apache.markmail.org/thread/p73loqtvbzvfzsv5).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The change is needed to protect end-users from fetching edge versions of the plugin by incompatible version of cordova.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Published 1.8.2 and 2.0.1 version of the plugin under personal scope (`@kotikov.vladimir/phonegap-plugin-push`) and ran `cordova plugin add` to ensure that desired plugin version is being fetched and installed

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.