### PR TITLE
Unused variable app. Caused warnings.

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -589,8 +589,6 @@
     [self.commandDelegate runInBackground:^ {
         NSString* notId = [command.arguments objectAtIndex:0];
 
-        UIApplication *app = [UIApplication sharedApplication];
-
         dispatch_async(dispatch_get_main_queue(), ^{
             [NSTimer scheduledTimerWithTimeInterval:0.1
                                              target:self


### PR DESCRIPTION
Unused variable app. Caused warnings.

## Description
Unused variable app. Caused warnings.

## Motivation and Context
This plugin causes so many warnings and it is not pro.

## Types of changes
- [x] warnings.
