### PR TITLE
1. Using UNUserNotificationCenterDelegate (required to know the app s…

### DIFF
--- a/src/ios/AppDelegate+notification.h
+++ b/src/ios/AppDelegate+notification.h
@@ -7,11 +7,14 @@
 //
 
 #import "AppDelegate.h"
+#import <UserNotifications/UserNotifications.h>
 
-@interface AppDelegate (notification)
+@interface AppDelegate (notification) <UNUserNotificationCenterDelegate>
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:( void (^)(UIBackgroundFetchResult))completionHandler;
+
+
 - (void)pushPluginOnApplicationDidBecomeActive:(UIApplication *)application;
 - (void)application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo completionHandler:(void(^)())completionHandler;
 - (id) getCommandInstance:(NSString*)className;

--- a/src/ios/PushPlugin.h
+++ b/src/ios/PushPlugin.h
@@ -26,6 +26,9 @@
 #import <Foundation/Foundation.h>
 #import <Cordova/CDV.h>
 #import <Cordova/CDVPlugin.h>
+#import <UserNotifications/UserNotifications.h>
+#define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
+#define SYSTEM_VERSION_LESS_THAN(v)                 ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
 
 @protocol GGLInstanceIDDelegate;
 @protocol GCMReceiverDelegate;

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -1,16 +1,16 @@
 /*
  Copyright 2009-2011 Urban Airship Inc. All rights reserved.
- 
+
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:
- 
+
  1. Redistributions of source code must retain the above copyright notice, this
  list of conditions and the following disclaimer.
- 
+
  2. Redistributions in binaryform must reproduce the above copyright notice,
  this list of conditions and the following disclaimer in the documentation
  and/or other materials provided withthe distribution.
- 
+
  THIS SOFTWARE IS PROVIDED BY THE URBAN AIRSHIP INC``AS IS'' AND ANY EXPRESS OR
  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
@@ -181,7 +181,7 @@
             UserNotificationTypes |= UIUserNotificationTypeBadge;
 #endif
         }
-        
+
         if (([soundArg isKindOfClass:[NSString class]] && [soundArg isEqualToString:@"true"]) || [soundArg boolValue])
         {
             notificationTypes |= UIRemoteNotificationTypeSound;
@@ -189,7 +189,7 @@
             UserNotificationTypes |= UIUserNotificationTypeSound;
 #endif
         }
-        
+
         if (([alertArg isKindOfClass:[NSString class]] && [alertArg isEqualToString:@"true"]) || [alertArg boolValue])
         {
             notificationTypes |= UIRemoteNotificationTypeAlert;
@@ -197,12 +197,12 @@
             UserNotificationTypes |= UIUserNotificationTypeAlert;
 #endif
         }
-        
+
         notificationTypes |= UIRemoteNotificationTypeNewsstandContentAvailability;
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
         UserNotificationTypes |= UIUserNotificationActivationModeBackground;
 #endif
-        
+
         if (clearBadgeArg == nil || ([clearBadgeArg isKindOfClass:[NSString class]] && [clearBadgeArg isEqualToString:@"false"]) || ![clearBadgeArg boolValue]) {
             NSLog(@"PushPlugin.register: setting badge to false");
             clearBadge = NO;
@@ -212,12 +212,12 @@
             [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
         }
         NSLog(@"PushPlugin.register: clear badge is set to %d", clearBadge);
-        
+
         if (notificationTypes == UIRemoteNotificationTypeNone)
             NSLog(@"PushPlugin.register: Push notification type is set to none");
-        
+
         isInline = NO;
-        
+
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
         NSLog(@"PushPlugin.register: better button setup");
         // setup action buttons
@@ -227,7 +227,7 @@
             for (id key in categoryOptions) {
                 NSLog(@"categories: key %@", key);
                 id category = [categoryOptions objectForKey:key];
-                
+
                 id yesButton = [category objectForKey:@"yes"];
                 UIMutableUserNotificationAction *yesAction;
                 if (yesButton != nil && [yesButton  isKindOfClass:[NSDictionary class]]) {
@@ -243,13 +243,13 @@
                 if (maybeButton != nil && [maybeButton  isKindOfClass:[NSDictionary class]]) {
                     maybeAction = [self createAction: maybeButton];
                 }
-                
+
                 // First create the category
                 UIMutableUserNotificationCategory *notificationCategory = [[UIMutableUserNotificationCategory alloc] init];
-                
+
                 // Identifier to include in your push payload and local notification
                 notificationCategory.identifier = key;
-                
+
                 NSMutableArray *categoryArray = [[NSMutableArray alloc] init];
                 NSMutableArray *minimalCategoryArray = [[NSMutableArray alloc] init];
                 if (yesButton != nil) {
@@ -327,7 +327,7 @@
             [self setUsesGCM:NO];
         }
         id gcmSandBoxArg = [iosOptions objectForKey:@"gcmSandbox"];
-        
+
         [self setGcmSandbox:@NO];
         if ([self usesGCM] &&
             (([gcmSandBoxArg isKindOfClass:[NSString class]] && [gcmSandBoxArg isEqualToString:@"true"]) ||
@@ -336,7 +336,7 @@
             NSLog(@"Using GCM Sandbox");
             [self setGcmSandbox:@YES];
         }
-        
+
         if (notificationMessage) {			// if there is a pending startup notification
             dispatch_async(dispatch_get_main_queue(), ^{
                 // delay to allow JS event handlers to be setup
@@ -347,9 +347,9 @@
 }
 
 - (UIMutableUserNotificationAction *)createAction:(NSDictionary *)dictionary {
-    
+
     UIMutableUserNotificationAction *myAction = [[UIMutableUserNotificationAction alloc] init];
-    
+
     myAction = [[UIMutableUserNotificationAction alloc] init];
     myAction.identifier = [dictionary objectForKey:@"callback"];
     myAction.title = [dictionary objectForKey:@"title"];
@@ -366,7 +366,7 @@
         myAction.destructive = YES;
     }
     myAction.authenticationRequired = NO;
-    
+
     return myAction;
 }
 
@@ -376,33 +376,33 @@
         return;
     }
     NSLog(@"Push Plugin register success: %@", deviceToken);
-    
+
     NSMutableDictionary *results = [NSMutableDictionary dictionary];
     NSString *token = [[[[deviceToken description] stringByReplacingOccurrencesOfString:@"<"withString:@""]
                         stringByReplacingOccurrencesOfString:@">" withString:@""]
                        stringByReplacingOccurrencesOfString: @" " withString: @""];
     [results setValue:token forKey:@"deviceToken"];
-    
+
 #if !TARGET_IPHONE_SIMULATOR
     // Get Bundle Info for Remote Registration (handy if you have more than one app)
     [results setValue:[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleDisplayName"] forKey:@"appName"];
     [results setValue:[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"] forKey:@"appVersion"];
-    
+
     // Check what Notifications the user has turned on.  We registered for all three, but they may have manually disabled some or all of them.
 #define SYSTEM_VERSION_LESS_THAN(v) ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
-    
+
     NSUInteger rntypes;
     if (!SYSTEM_VERSION_LESS_THAN(@"8.0")) {
         rntypes = [[[UIApplication sharedApplication] currentUserNotificationSettings] types];
     } else {
         rntypes = [[UIApplication sharedApplication] enabledRemoteNotificationTypes];
     }
-    
+
     // Set the defaults to disabled unless we find otherwise...
     NSString *pushBadge = @"disabled";
     NSString *pushAlert = @"disabled";
     NSString *pushSound = @"disabled";
-    
+
     // Check what Registered Types are turned on. This is a bit tricky since if two are enabled, and one is off, it will return a number 2... not telling you which
     // one is actually disabled. So we are literally checking to see if rnTypes matches what is turned on, instead of by number. The "tricky" part is that the
     // single notification types will only match if they are the ONLY one enabled.  Likewise, when we are checking for a pair of notifications, it will only be
@@ -416,34 +416,34 @@
     if(rntypes & UIRemoteNotificationTypeSound) {
         pushSound = @"enabled";
     }
-    
+
     [results setValue:pushBadge forKey:@"pushBadge"];
     [results setValue:pushAlert forKey:@"pushAlert"];
     [results setValue:pushSound forKey:@"pushSound"];
-    
+
     // Get the users Device Model, Display Name, Token & Version Number
     UIDevice *dev = [UIDevice currentDevice];
     [results setValue:dev.name forKey:@"deviceName"];
     [results setValue:dev.model forKey:@"deviceModel"];
     [results setValue:dev.systemVersion forKey:@"deviceSystemVersion"];
-    
+
     if([self usesGCM]) {
         GGLInstanceIDConfig *instanceIDConfig = [GGLInstanceIDConfig defaultConfig];
         instanceIDConfig.delegate = self;
         [[GGLInstanceID sharedInstance] startWithConfig:instanceIDConfig];
-        
+
         [self setGcmRegistrationOptions: @{kGGLInstanceIDRegisterAPNSOption:deviceToken,
                                            kGGLInstanceIDAPNSServerTypeSandboxOption:[self gcmSandbox]}];
-        
+
         [[GGLInstanceID sharedInstance] tokenWithAuthorizedEntity:[self gcmSenderId]
                                                             scope:kGGLInstanceIDScopeGCM
                                                           options:[self gcmRegistrationOptions]
                                                           handler:[self gcmRegistrationHandler]];
-        
+
         GCMConfig *gcmConfig = [GCMConfig defaultConfig];
         gcmConfig.receiverDelegate = self;
         [[GCMService sharedInstance] startWithConfig:gcmConfig];
-        
+
     } else {
         [self registerWithToken: token];
     }
@@ -462,21 +462,21 @@
 
 - (void)notificationReceived {
     NSLog(@"Notification received");
-    
+
     if (notificationMessage && self.callbackId != nil)
     {
         NSMutableDictionary* message = [NSMutableDictionary dictionaryWithCapacity:4];
         NSMutableDictionary* additionalData = [NSMutableDictionary dictionaryWithCapacity:4];
-        
-        
+
+
         for (id key in notificationMessage) {
             if ([key isEqualToString:@"aps"]) {
                 id aps = [notificationMessage objectForKey:@"aps"];
-                
+
                 for(id key in aps) {
                     NSLog(@"Push Plugin key: %@", key);
                     id value = [aps objectForKey:key];
-                    
+
                     if ([key isEqualToString:@"alert"]) {
                         if ([value isKindOfClass:[NSDictionary class]]) {
                             for (id messageKey in value) {
@@ -509,26 +509,26 @@
                 [additionalData setObject:[notificationMessage objectForKey:key] forKey:key];
             }
         }
-        
+
         if (isInline) {
             [additionalData setObject:[NSNumber numberWithBool:YES] forKey:@"foreground"];
         } else {
             [additionalData setObject:[NSNumber numberWithBool:NO] forKey:@"foreground"];
         }
-        
+
         if (coldstart) {
             [additionalData setObject:[NSNumber numberWithBool:YES] forKey:@"coldstart"];
         } else {
             [additionalData setObject:[NSNumber numberWithBool:NO] forKey:@"coldstart"];
         }
-        
+
         [message setObject:additionalData forKey:@"additionalData"];
-        
+
         // send notification message
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:message];
         [pluginResult setKeepCallbackAsBool:YES];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
-        
+
         self.coldstart = NO;
         self.notificationMessage = nil;
     }
@@ -538,9 +538,9 @@
 {
     NSMutableDictionary* options = [command.arguments objectAtIndex:0];
     int badge = [[options objectForKey:@"badge"] intValue] ?: 0;
-    
+
     [[UIApplication sharedApplication] setApplicationIconBadgeNumber:badge];
-    
+
     NSString* message = [NSString stringWithFormat:@"app badge count set to %d", badge];
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:message];
     [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
@@ -549,7 +549,7 @@
 - (void)getApplicationIconBadgeNumber:(CDVInvokedUrlCommand *)command
 {
     NSInteger badge = [UIApplication sharedApplication].applicationIconBadgeNumber;
-    
+
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsInt:(int)badge];
     [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
 }
@@ -557,7 +557,7 @@
 - (void)clearAllNotifications:(CDVInvokedUrlCommand *)command
 {
     [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
-    
+
     NSString* message = [NSString stringWithFormat:@"cleared all notifications"];
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:message];
     [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
@@ -570,7 +570,7 @@
     if ([appDelegate respondsToSelector:@selector(userHasRemoteNotificationsEnabled)]) {
         enabled = [appDelegate performSelector:@selector(userHasRemoteNotificationsEnabled)];
     }
-    
+
     NSMutableDictionary* message = [NSMutableDictionary dictionaryWithCapacity:1];
     [message setObject:[NSNumber numberWithBool:enabled] forKey:@"isEnabled"];
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:message];
@@ -600,19 +600,17 @@
 {
     NSString        *errorMessage = (error) ? [NSString stringWithFormat:@"%@ - %@", message, [error localizedDescription]] : message;
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:errorMessage];
-    
+
     [self.commandDelegate sendPluginResult:commandResult callbackId:self.callbackId];
 }
 
 -(void) finish:(CDVInvokedUrlCommand*)command
 {
     NSLog(@"Push Plugin finish called");
-    
+
     [self.commandDelegate runInBackground:^ {
         NSString* notId = [command.arguments objectAtIndex:0];
-        
-        UIApplication *app = [UIApplication sharedApplication];
-        
+
         dispatch_async(dispatch_get_main_queue(), ^{
             [NSTimer scheduledTimerWithTimeInterval:0.1
                                              target:self
@@ -620,7 +618,7 @@
                                            userInfo:notId
                                             repeats:NO];
         });
-        
+
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
@@ -629,9 +627,9 @@
 -(void)stopBackgroundTask:(NSTimer*)timer
 {
     UIApplication *app = [UIApplication sharedApplication];
-    
+
     NSLog(@"Push Plugin stopBackgroundTask called");
-    
+
     if (handlerObj) {
         NSLog(@"Push Plugin handlerObj");
         completionHandler = [handlerObj[[timer userInfo]] copy];
@@ -642,21 +640,5 @@
         }
     }
 }
-
-//- (void)userNotificationCenter:(UNUserNotificationCenter *)center
-//       willPresentNotification:(UNNotification *)notification
-//         withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler
-//{
-//    NSLog( @"Handle push from foreground" );
-//    // custom code to handle push while app is in the foreground
-//}
-//
-//- (void)userNotificationCenter:(UNUserNotificationCenter *)center
-//didReceiveNotificationResponse:(UNNotificationResponse *)response
-//         withCompletionHandler:(void (^)())completionHandler
-//{
-//    NSLog( @"Handle push from background or closed" );
-//    // if you set a member variable in didReceiveRemoteNotification, you will know if this is from closed or background
-//}
 
 @end

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -1,16 +1,16 @@
 /*
  Copyright 2009-2011 Urban Airship Inc. All rights reserved.
-
+ 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:
-
+ 
  1. Redistributions of source code must retain the above copyright notice, this
  list of conditions and the following disclaimer.
-
+ 
  2. Redistributions in binaryform must reproduce the above copyright notice,
  this list of conditions and the following disclaimer in the documentation
  and/or other materials provided withthe distribution.
-
+ 
  THIS SOFTWARE IS PROVIDED BY THE URBAN AIRSHIP INC``AS IS'' AND ANY EXPRESS OR
  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
@@ -28,6 +28,7 @@
 
 #import "PushPlugin.h"
 #import "CloudMessaging.h"
+#import <UserNotifications/UserNotifications.h>
 
 @implementation PushPlugin : CDVPlugin
 
@@ -56,30 +57,30 @@
         if (registrationToken != nil) {
             NSLog(@"GCM Registration Token: %@", registrationToken);
             [weakSelf setGcmRegistrationToken: registrationToken];
-
+            
             id topics = [weakSelf gcmTopics];
             if (topics != nil) {
                 for (NSString *topic in topics) {
                     NSLog(@"subscribe from topic: %@", topic);
                     id pubSub = [GCMPubSub sharedInstance];
                     [pubSub subscribeWithToken: [weakSelf gcmRegistrationToken]
-                        topic:[NSString stringWithFormat:@"/topics/%@", topic]
-                        options:nil
-                        handler:^void(NSError *error) {
-                            if (error) {
-                                if (error.code == 3001) {
-                                    NSLog(@"Already subscribed to %@", topic);
-                                } else {
-                                    NSLog(@"Failed to subscribe to topic %@: %@", topic, error);
-                                }
-                            }
-                            else {
-                                NSLog(@"Successfully subscribe to topic %@", topic);
-                            }
-                    }];
+                                         topic:[NSString stringWithFormat:@"/topics/%@", topic]
+                                       options:nil
+                                       handler:^void(NSError *error) {
+                                           if (error) {
+                                               if (error.code == 3001) {
+                                                   NSLog(@"Already subscribed to %@", topic);
+                                               } else {
+                                                   NSLog(@"Failed to subscribe to topic %@: %@", topic, error);
+                                               }
+                                           }
+                                           else {
+                                               NSLog(@"Successfully subscribe to topic %@", topic);
+                                           }
+                                       }];
                 }
             }
-
+            
             [weakSelf registerWithToken:registrationToken];
         } else {
             NSLog(@"Registration to GCM failed with error: %@", error.localizedDescription);
@@ -125,24 +126,24 @@
 - (void)unregister:(CDVInvokedUrlCommand*)command;
 {
     self.callbackId = command.callbackId;
-
+    
     NSArray* topics = [command argumentAtIndex:0];
-
+    
     if (topics != nil) {
         id pubSub = [GCMPubSub sharedInstance];
         for (NSString *topic in topics) {
             NSLog(@"unsubscribe from topic: %@", topic);
             [pubSub unsubscribeWithToken: [self gcmRegistrationToken]
-                topic:[NSString stringWithFormat:@"/topics/%@", topic]
-                options:nil
-                handler:^void(NSError *error) {
-                    if (error) {
-                        NSLog(@"Failed to unsubscribe from topic %@: %@", topic, error);
-                    }
-                    else {
-                        NSLog(@"Successfully unsubscribe from topic %@", topic);
-                    }
-            }];
+                                   topic:[NSString stringWithFormat:@"/topics/%@", topic]
+                                 options:nil
+                                 handler:^void(NSError *error) {
+                                     if (error) {
+                                         NSLog(@"Failed to unsubscribe from topic %@: %@", topic, error);
+                                     }
+                                     else {
+                                         NSLog(@"Successfully unsubscribe from topic %@", topic);
+                                     }
+                                 }];
         }
     } else {
         [[UIApplication sharedApplication] unregisterForRemoteNotifications];
@@ -153,26 +154,26 @@
 - (void)init:(CDVInvokedUrlCommand*)command;
 {
     [self.commandDelegate runInBackground:^ {
-
+        
         NSLog(@"Push Plugin register called");
         self.callbackId = command.callbackId;
-
+        
         NSMutableDictionary* options = [command.arguments objectAtIndex:0];
         NSMutableDictionary* iosOptions = [options objectForKey:@"ios"];
-
-    NSArray* topics = [iosOptions objectForKey:@"topics"];
-    [self setGcmTopics:topics];
-
+        
+        NSArray* topics = [iosOptions objectForKey:@"topics"];
+        [self setGcmTopics:topics];
+        
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
         UIUserNotificationType UserNotificationTypes = UIUserNotificationTypeNone;
 #endif
         UIRemoteNotificationType notificationTypes = UIRemoteNotificationTypeNone;
-
+        
         id badgeArg = [iosOptions objectForKey:@"badge"];
         id soundArg = [iosOptions objectForKey:@"sound"];
         id alertArg = [iosOptions objectForKey:@"alert"];
         id clearBadgeArg = [iosOptions objectForKey:@"clearBadge"];
-
+        
         if (([badgeArg isKindOfClass:[NSString class]] && [badgeArg isEqualToString:@"true"]) || [badgeArg boolValue])
         {
             notificationTypes |= UIRemoteNotificationTypeBadge;
@@ -180,7 +181,7 @@
             UserNotificationTypes |= UIUserNotificationTypeBadge;
 #endif
         }
-
+        
         if (([soundArg isKindOfClass:[NSString class]] && [soundArg isEqualToString:@"true"]) || [soundArg boolValue])
         {
             notificationTypes |= UIRemoteNotificationTypeSound;
@@ -188,7 +189,7 @@
             UserNotificationTypes |= UIUserNotificationTypeSound;
 #endif
         }
-
+        
         if (([alertArg isKindOfClass:[NSString class]] && [alertArg isEqualToString:@"true"]) || [alertArg boolValue])
         {
             notificationTypes |= UIRemoteNotificationTypeAlert;
@@ -196,12 +197,12 @@
             UserNotificationTypes |= UIUserNotificationTypeAlert;
 #endif
         }
-
+        
         notificationTypes |= UIRemoteNotificationTypeNewsstandContentAvailability;
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
         UserNotificationTypes |= UIUserNotificationActivationModeBackground;
 #endif
-
+        
         if (clearBadgeArg == nil || ([clearBadgeArg isKindOfClass:[NSString class]] && [clearBadgeArg isEqualToString:@"false"]) || ![clearBadgeArg boolValue]) {
             NSLog(@"PushPlugin.register: setting badge to false");
             clearBadge = NO;
@@ -211,12 +212,12 @@
             [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
         }
         NSLog(@"PushPlugin.register: clear badge is set to %d", clearBadge);
-
+        
         if (notificationTypes == UIRemoteNotificationTypeNone)
             NSLog(@"PushPlugin.register: Push notification type is set to none");
-
+        
         isInline = NO;
-
+        
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
         NSLog(@"PushPlugin.register: better button setup");
         // setup action buttons
@@ -226,7 +227,7 @@
             for (id key in categoryOptions) {
                 NSLog(@"categories: key %@", key);
                 id category = [categoryOptions objectForKey:key];
-
+                
                 id yesButton = [category objectForKey:@"yes"];
                 UIMutableUserNotificationAction *yesAction;
                 if (yesButton != nil && [yesButton  isKindOfClass:[NSDictionary class]]) {
@@ -242,13 +243,13 @@
                 if (maybeButton != nil && [maybeButton  isKindOfClass:[NSDictionary class]]) {
                     maybeAction = [self createAction: maybeButton];
                 }
-
+                
                 // First create the category
                 UIMutableUserNotificationCategory *notificationCategory = [[UIMutableUserNotificationCategory alloc] init];
-
+                
                 // Identifier to include in your push payload and local notification
                 notificationCategory.identifier = key;
-
+                
                 NSMutableArray *categoryArray = [[NSMutableArray alloc] init];
                 NSMutableArray *minimalCategoryArray = [[NSMutableArray alloc] init];
                 if (yesButton != nil) {
@@ -262,37 +263,58 @@
                 if (maybeButton != nil) {
                     [categoryArray addObject:maybeAction];
                 }
-
+                
                 // Add the actions to the category and set the action context
                 [notificationCategory setActions:categoryArray forContext:UIUserNotificationActionContextDefault];
-
+                
                 // Set the actions to present in a minimal context
                 [notificationCategory setActions:minimalCategoryArray forContext:UIUserNotificationActionContextMinimal];
-
+                
                 NSLog(@"Adding category %@", key);
                 [categories addObject:notificationCategory];
             }
-
+            
         }
 #else
         NSLog(@"PushPlugin.register: action buttons only supported on iOS8 and above");
 #endif
-
-
+        
+        
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
-        if ([[UIApplication sharedApplication]respondsToSelector:@selector(registerUserNotificationSettings:)]) {
-            UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:UserNotificationTypes categories:categories];
-            [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
-            [[UIApplication sharedApplication] registerForRemoteNotifications];
-        } else {
-            [[UIApplication sharedApplication] registerForRemoteNotificationTypes:
-             (UIRemoteNotificationTypeBadge | UIRemoteNotificationTypeSound | UIRemoteNotificationTypeAlert)];
+        if( SYSTEM_VERSION_LESS_THAN( @"10.0" ) )  {
+            if ([[UIApplication sharedApplication]respondsToSelector:@selector(registerUserNotificationSettings:)]) {
+                UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:UserNotificationTypes categories:categories];
+                [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
+                [[UIApplication sharedApplication] registerForRemoteNotifications];
+            } else {
+                [[UIApplication sharedApplication] registerForRemoteNotificationTypes:
+                 (UIRemoteNotificationTypeBadge | UIRemoteNotificationTypeSound | UIRemoteNotificationTypeAlert)];
+            }
+            
+        }else{
+            UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+//            center.delegate = self;
+            [center requestAuthorizationWithOptions:(UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionBadge) completionHandler:^(BOOL granted, NSError * _Nullable error)
+             {
+                 if( !error )
+                 {
+                     [[UIApplication sharedApplication] registerForRemoteNotifications]; // required to get the app to do anything at all about push notifications
+                     NSLog( @"Push registration success." );
+                 }
+                 else
+                 {
+                     NSLog( @"Push registration FAILED" );
+                     NSLog( @"ERROR: %@ - %@", error.localizedFailureReason, error.localizedDescription );
+                     NSLog( @"SUGGESTIONS: %@ - %@", error.localizedRecoveryOptions, error.localizedRecoverySuggestion );
+                 }
+             }];
+            
         }
 #else
         [[UIApplication sharedApplication] registerForRemoteNotificationTypes:
          (UIRemoteNotificationTypeBadge | UIRemoteNotificationTypeSound | UIRemoteNotificationTypeAlert)];
 #endif
-
+        
         //  GCM options
         [self setGcmSenderId: [iosOptions objectForKey:@"senderID"]];
         NSLog(@"GCM Sender ID %@", gcmSenderId);
@@ -305,7 +327,7 @@
             [self setUsesGCM:NO];
         }
         id gcmSandBoxArg = [iosOptions objectForKey:@"gcmSandbox"];
-
+        
         [self setGcmSandbox:@NO];
         if ([self usesGCM] &&
             (([gcmSandBoxArg isKindOfClass:[NSString class]] && [gcmSandBoxArg isEqualToString:@"true"]) ||
@@ -314,7 +336,7 @@
             NSLog(@"Using GCM Sandbox");
             [self setGcmSandbox:@YES];
         }
-
+        
         if (notificationMessage) {			// if there is a pending startup notification
             dispatch_async(dispatch_get_main_queue(), ^{
                 // delay to allow JS event handlers to be setup
@@ -325,9 +347,9 @@
 }
 
 - (UIMutableUserNotificationAction *)createAction:(NSDictionary *)dictionary {
-
+    
     UIMutableUserNotificationAction *myAction = [[UIMutableUserNotificationAction alloc] init];
-
+    
     myAction = [[UIMutableUserNotificationAction alloc] init];
     myAction.identifier = [dictionary objectForKey:@"callback"];
     myAction.title = [dictionary objectForKey:@"title"];
@@ -344,7 +366,7 @@
         myAction.destructive = YES;
     }
     myAction.authenticationRequired = NO;
-
+    
     return myAction;
 }
 
@@ -354,33 +376,33 @@
         return;
     }
     NSLog(@"Push Plugin register success: %@", deviceToken);
-
+    
     NSMutableDictionary *results = [NSMutableDictionary dictionary];
     NSString *token = [[[[deviceToken description] stringByReplacingOccurrencesOfString:@"<"withString:@""]
                         stringByReplacingOccurrencesOfString:@">" withString:@""]
                        stringByReplacingOccurrencesOfString: @" " withString: @""];
     [results setValue:token forKey:@"deviceToken"];
-
+    
 #if !TARGET_IPHONE_SIMULATOR
     // Get Bundle Info for Remote Registration (handy if you have more than one app)
     [results setValue:[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleDisplayName"] forKey:@"appName"];
     [results setValue:[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"] forKey:@"appVersion"];
-
+    
     // Check what Notifications the user has turned on.  We registered for all three, but they may have manually disabled some or all of them.
 #define SYSTEM_VERSION_LESS_THAN(v) ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
-
+    
     NSUInteger rntypes;
     if (!SYSTEM_VERSION_LESS_THAN(@"8.0")) {
         rntypes = [[[UIApplication sharedApplication] currentUserNotificationSettings] types];
     } else {
         rntypes = [[UIApplication sharedApplication] enabledRemoteNotificationTypes];
     }
-
+    
     // Set the defaults to disabled unless we find otherwise...
     NSString *pushBadge = @"disabled";
     NSString *pushAlert = @"disabled";
     NSString *pushSound = @"disabled";
-
+    
     // Check what Registered Types are turned on. This is a bit tricky since if two are enabled, and one is off, it will return a number 2... not telling you which
     // one is actually disabled. So we are literally checking to see if rnTypes matches what is turned on, instead of by number. The "tricky" part is that the
     // single notification types will only match if they are the ONLY one enabled.  Likewise, when we are checking for a pair of notifications, it will only be
@@ -394,34 +416,34 @@
     if(rntypes & UIRemoteNotificationTypeSound) {
         pushSound = @"enabled";
     }
-
+    
     [results setValue:pushBadge forKey:@"pushBadge"];
     [results setValue:pushAlert forKey:@"pushAlert"];
     [results setValue:pushSound forKey:@"pushSound"];
-
+    
     // Get the users Device Model, Display Name, Token & Version Number
     UIDevice *dev = [UIDevice currentDevice];
     [results setValue:dev.name forKey:@"deviceName"];
     [results setValue:dev.model forKey:@"deviceModel"];
     [results setValue:dev.systemVersion forKey:@"deviceSystemVersion"];
-
+    
     if([self usesGCM]) {
         GGLInstanceIDConfig *instanceIDConfig = [GGLInstanceIDConfig defaultConfig];
         instanceIDConfig.delegate = self;
         [[GGLInstanceID sharedInstance] startWithConfig:instanceIDConfig];
-
+        
         [self setGcmRegistrationOptions: @{kGGLInstanceIDRegisterAPNSOption:deviceToken,
                                            kGGLInstanceIDAPNSServerTypeSandboxOption:[self gcmSandbox]}];
-
+        
         [[GGLInstanceID sharedInstance] tokenWithAuthorizedEntity:[self gcmSenderId]
                                                             scope:kGGLInstanceIDScopeGCM
                                                           options:[self gcmRegistrationOptions]
                                                           handler:[self gcmRegistrationHandler]];
-
+        
         GCMConfig *gcmConfig = [GCMConfig defaultConfig];
         gcmConfig.receiverDelegate = self;
         [[GCMService sharedInstance] startWithConfig:gcmConfig];
-
+        
     } else {
         [self registerWithToken: token];
     }
@@ -440,21 +462,21 @@
 
 - (void)notificationReceived {
     NSLog(@"Notification received");
-
+    
     if (notificationMessage && self.callbackId != nil)
     {
         NSMutableDictionary* message = [NSMutableDictionary dictionaryWithCapacity:4];
         NSMutableDictionary* additionalData = [NSMutableDictionary dictionaryWithCapacity:4];
-
-
+        
+        
         for (id key in notificationMessage) {
             if ([key isEqualToString:@"aps"]) {
                 id aps = [notificationMessage objectForKey:@"aps"];
-
+                
                 for(id key in aps) {
                     NSLog(@"Push Plugin key: %@", key);
                     id value = [aps objectForKey:key];
-
+                    
                     if ([key isEqualToString:@"alert"]) {
                         if ([value isKindOfClass:[NSDictionary class]]) {
                             for (id messageKey in value) {
@@ -487,26 +509,26 @@
                 [additionalData setObject:[notificationMessage objectForKey:key] forKey:key];
             }
         }
-
+        
         if (isInline) {
             [additionalData setObject:[NSNumber numberWithBool:YES] forKey:@"foreground"];
         } else {
             [additionalData setObject:[NSNumber numberWithBool:NO] forKey:@"foreground"];
         }
-
+        
         if (coldstart) {
             [additionalData setObject:[NSNumber numberWithBool:YES] forKey:@"coldstart"];
         } else {
             [additionalData setObject:[NSNumber numberWithBool:NO] forKey:@"coldstart"];
         }
-
+        
         [message setObject:additionalData forKey:@"additionalData"];
-
+        
         // send notification message
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:message];
         [pluginResult setKeepCallbackAsBool:YES];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
-
+        
         self.coldstart = NO;
         self.notificationMessage = nil;
     }
@@ -516,9 +538,9 @@
 {
     NSMutableDictionary* options = [command.arguments objectAtIndex:0];
     int badge = [[options objectForKey:@"badge"] intValue] ?: 0;
-
+    
     [[UIApplication sharedApplication] setApplicationIconBadgeNumber:badge];
-
+    
     NSString* message = [NSString stringWithFormat:@"app badge count set to %d", badge];
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:message];
     [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
@@ -527,7 +549,7 @@
 - (void)getApplicationIconBadgeNumber:(CDVInvokedUrlCommand *)command
 {
     NSInteger badge = [UIApplication sharedApplication].applicationIconBadgeNumber;
-
+    
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsInt:(int)badge];
     [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
 }
@@ -535,7 +557,7 @@
 - (void)clearAllNotifications:(CDVInvokedUrlCommand *)command
 {
     [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
-
+    
     NSString* message = [NSString stringWithFormat:@"cleared all notifications"];
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:message];
     [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
@@ -548,7 +570,7 @@
     if ([appDelegate respondsToSelector:@selector(userHasRemoteNotificationsEnabled)]) {
         enabled = [appDelegate performSelector:@selector(userHasRemoteNotificationsEnabled)];
     }
-
+    
     NSMutableDictionary* message = [NSMutableDictionary dictionaryWithCapacity:1];
     [message setObject:[NSNumber numberWithBool:enabled] forKey:@"isEnabled"];
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:message];
@@ -578,17 +600,19 @@
 {
     NSString        *errorMessage = (error) ? [NSString stringWithFormat:@"%@ - %@", message, [error localizedDescription]] : message;
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:errorMessage];
-
+    
     [self.commandDelegate sendPluginResult:commandResult callbackId:self.callbackId];
 }
 
 -(void) finish:(CDVInvokedUrlCommand*)command
 {
     NSLog(@"Push Plugin finish called");
-
+    
     [self.commandDelegate runInBackground:^ {
         NSString* notId = [command.arguments objectAtIndex:0];
-
+        
+        UIApplication *app = [UIApplication sharedApplication];
+        
         dispatch_async(dispatch_get_main_queue(), ^{
             [NSTimer scheduledTimerWithTimeInterval:0.1
                                              target:self
@@ -596,7 +620,7 @@
                                            userInfo:notId
                                             repeats:NO];
         });
-
+        
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
@@ -605,9 +629,9 @@
 -(void)stopBackgroundTask:(NSTimer*)timer
 {
     UIApplication *app = [UIApplication sharedApplication];
-
+    
     NSLog(@"Push Plugin stopBackgroundTask called");
-
+    
     if (handlerObj) {
         NSLog(@"Push Plugin handlerObj");
         completionHandler = [handlerObj[[timer userInfo]] copy];
@@ -618,5 +642,21 @@
         }
     }
 }
+
+//- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+//       willPresentNotification:(UNNotification *)notification
+//         withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler
+//{
+//    NSLog( @"Handle push from foreground" );
+//    // custom code to handle push while app is in the foreground
+//}
+//
+//- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+//didReceiveNotificationResponse:(UNNotificationResponse *)response
+//         withCompletionHandler:(void (^)())completionHandler
+//{
+//    NSLog( @"Handle push from background or closed" );
+//    // if you set a member variable in didReceiveRemoteNotification, you will know if this is from closed or background
+//}
 
 @end


### PR DESCRIPTION
 Using UNUserNotificationCenter to handle push notification in iOS10
## Description

application:didReceiveRemoteNotification does not properly detect the app's state is iOS10
and not fired after app wakes up from background by tapping a notification.
## Related Issue
#1265
## How Has This Been Tested?

I tested on my own iOS 10 phone and iOS 9 iPad.
## Screenshots (if appropriate):
## Types of changes
- [ X] Bug fix (non-breaking change which fixes an issue)
## Checklist:
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
