### PR TITLE
Issue #1213: XDK instructions link for www template is incorrect

### DIFF
--- a/docs/PHONEGAP_BUILD.md
+++ b/docs/PHONEGAP_BUILD.md
@@ -53,7 +53,7 @@ c. iOS Distribution cert: create (if needed), download and install (if needed), 
 d. Make an AdHoc Provisioning Profile using your App ID from (1a) and your cert from (1c).  Make sure your test device is enabled.  Download and save with a name you will recognize. (you'll need to add this to your Intel XDK project later)
 e. make a push cert, download it, install it, export it to .p12, convert it to .pem (this is for the push server that will send the notification - you'll need this later to test your Intel XDK app)
 
-2. In Intel XDK, make a new Cordova CLI 5.4.1 project using the HTML5+Cordova Blank Template, then replace the contents of www with [the contents of www from the PhoneGap Push Template](https://github.com/phonegap/phonegap-template-push/tree/master/www).
+2. In Intel XDK, make a new Cordova CLI 5.4.1 project using the HTML5+Cordova Blank Template, then replace the contents of www with [the contents of www from the PhoneGap Push Template](https://github.com/phonegap/phonegap-template-push/tree/master/template_src/www).
 
 3. Delete www/config.xml (optional? Intel XDK does not use config.xml)
 


### PR DESCRIPTION
## Description
Updated URL in PHONEGAP_BUILD markdown to reflect changed structure of linked repo.

## Related Issue
https://github.com/phonegap/phonegap-plugin-push/issues/1213

## Motivation and Context
Fixes broken link.

## How Has This Been Tested?
Tested in my fork - link now works.

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

