### PR TITLE
Issue#1282 Show app name if title is empty

### DIFF
--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -290,6 +290,10 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
 
             Log.d(LOG_TAG, "create notification");
 
+            if(title == null || title.isEmpty()){
+                extras.putString(TITLE, getAppName(this));
+            }
+
             createNotification(context, extras);
         }
 


### PR DESCRIPTION
Show app name as the title in Android if title is empty in push payload

## Description
If title is empty we need to show app name as the title since it is the default behaviour.

## Related Issue
#1282 

## How Has This Been Tested?
Tested in Samsung Galaxy S5 (6.0.1) for both background and foreground notifications
with no title parameter, null, "" and with a value.


## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

