### PR TITLE
Issue1233 iOS: Return additional parameter to identify if push notification is received while app is inactive

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -203,6 +203,7 @@ Parameter | Type | Description
 `data.additionalData` | `Object` | An optional collection of data sent by the 3rd party push service that does not fit in the above properties.
 `data.additionalData.foreground` | `boolean` | Whether the notification was received while the app was in the foreground
 `data.additionalData.coldstart` | `boolean` | Will be `true` if the application is started by clicking on the push notification, `false` if the app is already started.
+`data.additionalData.inactive` | `boolean` | Whether the notification was received while the app was in inactive state (iOS Only)
 
 ### Example
 

--- a/src/ios/AppDelegate+notification.h
+++ b/src/ios/AppDelegate+notification.h
@@ -18,5 +18,6 @@
 
 @property (nonatomic, retain) NSDictionary  *launchNotification;
 @property (nonatomic, retain) NSNumber  *coldstart;
+@property (nonatomic, retain) NSNumber  *inactive;
 
 @end

--- a/src/ios/AppDelegate+notification.h
+++ b/src/ios/AppDelegate+notification.h
@@ -19,5 +19,6 @@
 @property (nonatomic, retain) NSDictionary  *launchNotification;
 @property (nonatomic, retain) NSNumber  *coldstart;
 @property (nonatomic, retain) NSNumber  *inactive;
+@property (nonatomic, retain) NSNumber  *inactivePush;
 
 @end

--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -13,6 +13,7 @@
 static char launchNotificationKey;
 static char coldstartKey;
 static char inactiveKey;
+static char inactivePushKey;
 
 @implementation AppDelegate (notification)
 
@@ -172,7 +173,7 @@ static char inactiveKey;
             NSLog(@"just put it in the shade");
             //save it for later
             self.launchNotification = userInfo;
-
+            self.inactivePush = self.inactive;
             completionHandler(UIBackgroundFetchResultNewData);
         }
     }
@@ -208,7 +209,7 @@ static char inactiveKey;
     if (self.launchNotification) {
         pushHandler.isInline = NO;
         pushHandler.coldstart = [self.coldstart boolValue];
-        pushHandler.inactive = [self.inactive boolValue];
+        pushHandler.inactive = [self.inactivePush boolValue];
         pushHandler.notificationMessage = self.launchNotification;
         self.launchNotification = nil;
         self.coldstart = [NSNumber numberWithBool:NO];
@@ -216,6 +217,7 @@ static char inactiveKey;
     }
 
     self.inactive = [NSNumber numberWithBool:NO];
+    self.inactivePush = [NSNumber numberWithBool:NO];
 }
 
 - (void)pushPluginOnApplicationDidEnterBackground:(NSNotification *)notification {
@@ -305,11 +307,22 @@ forRemoteNotification: (NSDictionary *) notification completionHandler: (void (^
     objc_setAssociatedObject(self, &inactiveKey, aNumber, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
+- (NSNumber *)inactivePush
+{
+    return objc_getAssociatedObject(self, &inactivePushKey);
+}
+
+- (void)setInactivePush:(NSNumber *)aNumber
+{
+    objc_setAssociatedObject(self, &inactivePushKey, aNumber, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
 - (void)dealloc
 {
     self.launchNotification = nil; // clear the association and release the object
     self.coldstart = nil;
     self.inactive = nil;
+    self.inactivePush = nil;
 }
 
 @end

--- a/src/ios/PushPlugin.h
+++ b/src/ios/PushPlugin.h
@@ -50,6 +50,7 @@
 @property (nonatomic, strong) NSDictionary *notificationMessage;
 @property BOOL isInline;
 @property BOOL coldstart;
+@property BOOL inactive;
 @property BOOL clearBadge;
 @property (nonatomic, strong) NSMutableDictionary *handlerObj;
 

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -34,6 +34,7 @@
 @synthesize notificationMessage;
 @synthesize isInline;
 @synthesize coldstart;
+@synthesize inactive;
 
 @synthesize callbackId;
 @synthesize notificationCallbackId;
@@ -554,6 +555,12 @@
             [additionalData setObject:[NSNumber numberWithBool:NO] forKey:@"coldstart"];
         }
 
+        if (inactive) {
+            [additionalData setObject:[NSNumber numberWithBool:YES] forKey:@"inactive"];
+        } else {
+            [additionalData setObject:[NSNumber numberWithBool:NO] forKey:@"inactive"];
+        }
+
         [message setObject:additionalData forKey:@"additionalData"];
 
         // send notification message
@@ -562,6 +569,7 @@
         [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
 
         self.coldstart = NO;
+        self.inactive = NO;
         self.notificationMessage = nil;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
There is no parameter to identify if push notification is received while app is inactive.
Added a parameter for iOS to indicated if push received while app is inactive

## Description
<!--- Describe your changes in detail -->
inactive variable is used to keep track of current app state.
inactivePush variable is set (to the value of inactive) at the time of push received.

## Related Issue
#1233 

## Motivation and Context
I wanted to differentiate notification event based on below 3 cases
1. User clicks on a push and open the app (need to open push summary screen directly)
2. Push received while app is foreground (need to show in-app message)
3. Push received while app is inactive (need to show in-app message)

## How Has This Been Tested?
Tested in 
iPad Air 2 (8.4)
iPad mini (10.0.1)
iPhone 6 (10.0.1)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.