### PR TITLE
Update GCM to 9.8+  issue #1319

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -58,7 +58,7 @@
     </config-file>
     <framework src="push.gradle" custom="true" type="gradleReference"/>
     <framework src="com.android.support:support-v13:23+"/>
-    <framework src="com.google.android.gms:play-services-gcm:9.0.2+"/>
+    <framework src="com.google.android.gms:play-services-gcm:9.8+"/>
     <framework src="me.leolin:ShortcutBadger:1.1.4@aar"/>
     <source-file src="src/android/com/adobe/phonegap/push/GCMIntentService.java" target-dir="src/com/adobe/phonegap/push/"/>
     <source-file src="src/android/com/adobe/phonegap/push/PushConstants.java" target-dir="src/com/adobe/phonegap/push/"/>


### PR DESCRIPTION
Old `gms:play-services-gcm:9.0.2+` will crash the app if you update your Google Play Services to the lastest version

## Description
Change

`gms:play-services-gcm:9.0.2+`

To

`gms:play-services-gcm:9.8.+`


## Related Issue

https://github.com/phonegap/phonegap-plugin-push/issues/1319

## Motivation and Context
Make the dependency up to date

## How Has This Been Tested?

Tested with Android 6.0.1 / Nexus 7

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

