### PR TITLE
Optional event emit instead of function call for action buttons

### DIFF
--- a/docs/PAYLOAD.md
+++ b/docs/PAYLOAD.md
@@ -606,7 +606,7 @@ This will produce the following notification in your tray:
 
 ![action_combo](https://cloud.githubusercontent.com/assets/353180/9313435/02554d2a-44f1-11e5-8cd9-0aadd1e02b18.png)
 
-If your users clicks on the main body of the notification your app will be opened. However if they click on either of the action buttons the app will open (or start) and the specified JavaScript callback will be executed. In this case it is `app.emailGuests` and `app.snooze` respectively. If you set the `foreground` property to `true` the app will be brought to the front, if `foreground` is `false` then the callback is run without the app being brought to the foreground.
+If your users clicks on the main body of the notification your app will be opened. However if they click on either of the action buttons the app will open (or start) and the specified JavaScript callback will be executed if there is a function defined, and if there isn't an event will be emitted with the callback name. In this case it is `app.emailGuests` and `app.snooze` respectively. If you set the `foreground` property to `true` the app will be brought to the front, if `foreground` is `false` then the callback is run without the app being brought to the foreground.
 
 ### In Line Replies
 
@@ -691,7 +691,7 @@ Attribute | Type | Default | Description
 --------- | ---- | ------- | -----------
 `icon` | `string` | | Optional. The name of a drawable resource to use as the small-icon. The name should not include the extension.
 `title` | `string` | | Required. The label to display for the action button.
-`callback` | `string` | | Required. The function to be executed when the action button is pressed. The function must be accessible from the global namespace. If you provide `myCallback` then it amounts to calling `window.myCallback`. If you provide `app.myCallback` then there needs to be an object call `app`, with a function called `myCallback` accessible from the global namespace, i.e. `window.app.myCallback`.
+`callback` | `string` | | Required. The function to be executed or the event to be emitted when the action button is pressed. The function must be accessible from the global namespace. If you provide `myCallback` then it amounts to calling `window.myCallback`. If you provide `app.myCallback` then there needs to be an object call `app`, with a function called `myCallback` accessible from the global namespace, i.e. `window.app.myCallback`. If there isn't a function with the specified name an event will be emitted with the callback name.
 `foreground` | `boolean` | `true` | Optional. Whether or not to bring the app to the foreground when the action button is pressed.
 `inline` | `boolean` | `false` | Optional. Whether or not to provide a quick reply text field to the user when the button is clicked.
 
@@ -1296,7 +1296,7 @@ but in order for the same `notification` event you would need to send your push 
     "registration_ids": ["my device id"],
     "notification": {
         "title": "My Title",
-    	"body": "My message"        
+    	"body": "My message"
     }
     "data": {
     	"key1": "data 1",
@@ -1316,7 +1316,7 @@ For some users of the plugin they are unable to get messages sent via GCM to sho
     "registration_ids": ["my device id"],
     "notification": {
         "title": "My Title",
-    	"body": "My message"        
+    	"body": "My message"
     },
     "priority": "high"
 }

--- a/www/push.js
+++ b/www/push.js
@@ -35,17 +35,21 @@ var PushNotification = function(options) {
         if (result && typeof result.registrationId !== 'undefined') {
             that.emit('registration', result);
         } else if (result && result.additionalData && typeof result.additionalData.actionCallback !== 'undefined') {
-            var executeFunctionByName = function(functionName, context /*, args */) {
-                var args = Array.prototype.slice.call(arguments, 2);
-                var namespaces = functionName.split('.');
-                var func = namespaces.pop();
-                for (var i = 0; i < namespaces.length; i++) {
-                    context = context[namespaces[i]];
-                }
-                return context[func].apply(context, args);
+            var executeFuctionOrEmitEventByName = function(callbackName, context, arg) {
+              var namespaces = callbackName.split('.');
+              var func = namespaces.pop();
+              for (var i = 0; i < namespaces.length; i++) {
+                context = context[namespaces[i]];
+              }
+
+              if (typeof context[func] === 'function') {
+                context[func].call(context, arg);
+              } else {
+                that.emit(callbackName, arg);
+              }
             };
 
-            executeFunctionByName(result.additionalData.actionCallback, window, result);
+            executeFuctionOrEmitEventByName(result.additionalData.actionCallback, window, result);
         } else if (result) {
             that.emit('notification', result);
         }
@@ -205,7 +209,7 @@ PushNotification.prototype.clearAllNotifications = function(successCallback, err
 /**
  * Listen for an event.
  *
- * The following events are supported:
+ * Any event is supported, but the following are built-in:
  *
  *   - registration
  *   - notification
@@ -216,9 +220,10 @@ PushNotification.prototype.clearAllNotifications = function(successCallback, err
  */
 
 PushNotification.prototype.on = function(eventName, callback) {
-    if (this._handlers.hasOwnProperty(eventName)) {
-        this._handlers[eventName].push(callback);
+    if (!this._handlers.hasOwnProperty(eventName)) {
+        this._handlers[eventName] = [];
     }
+    this._handlers[eventName].push(callback);
 };
 
 /**


### PR DESCRIPTION
## Description
Add the option to emit events instead of executing functions on action buttons click.

## Related Issue
#1192

## Motivation and Context
It's easier and IMO better to work with events instead of functions in this kind of situation.

## How Has This Been Tested?
I only tested the event emission.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
