### PR TITLE
Warn about android badge support in documentation

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -332,6 +332,8 @@ push.unsubscribe('my-topic', function() {
 
 Set the badge count visible when the app is not running
 
+> Note: badges are not supported on all Android devices. See [our payload documentation](PAYLOAD.md#badges) for more details.
+
 ### Parameters
 
 Parameter | Type | Default | Description


### PR DESCRIPTION
Adding a warning in API documentation for `setApplicationIconBadgeNumber`. Letting users know before they implement this method that it will not be supported on all Android devices.

## Description
Readme update.

## Related Issue
Initial concern raised here: https://github.com/phonegap/phonegap-plugin-push/issues/1374#issuecomment-262324294

## Motivation and Context
Avoid confusion with people expecting all Android devices to show badges.

## ~~How Has This Been Tested?~~
Testing not required, as it's simply a documentation change.

## Types of changes
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] ~~I have added tests to cover my changes.~~
- [ ] ~~All new and existing tests passed.~~

Concern initially raised: https://github.com/phonegap/phonegap-plugin-push/issues/1374#issuecomment-262324294