### PR TITLE
Ensures foreground is true when inline is set to true and Android version is earlier than N  

### DIFF
--- a/docs/PAYLOAD.md
+++ b/docs/PAYLOAD.md
@@ -606,7 +606,7 @@ This will produce the following notification in your tray:
 
 ![action_combo](https://cloud.githubusercontent.com/assets/353180/9313435/02554d2a-44f1-11e5-8cd9-0aadd1e02b18.png)
 
-If your users clicks on the main body of the notification your app will be opened. However if they click on either of the action buttons the app will open (or start) and the specified JavaScript callback will be executed. In this case it is `app.emailGuests` and `app.snooze` respectively. If you set the `foreground` property to `true` the app will be brought to the front, if `foreground` is `false` then the callback is run without the app being brought to the foreground.
+If your user clicks on the main body of the notification your app will be opened. However if they click on either of the action buttons the app will open (or start) and the specified JavaScript callback will be executed. In this case it is `app.emailGuests` and `app.snooze` respectively. If you set the `foreground` property to `true` the app will be brought to the front, if `foreground` is `false` then the callback is run without the app being brought to the foreground.
 
 ### In Line Replies
 
@@ -649,7 +649,7 @@ service.send(message, { registrationTokens: [ deviceID ] }, function (err, respo
 });
 ```
 
-On Android M and earlier the action buttons will work exactly the same as before but on Android N and greater when the user clicks on the Email Guests button you will see the following:
+On Android N and greater when the user clicks on the Email Guests button they will see the following:
 
 ![inline_reply](https://cloud.githubusercontent.com/assets/353180/17107608/f35c208e-525d-11e6-94de-a3590c6f500d.png)
 
@@ -684,6 +684,8 @@ Then your app's `on('notification')` event handler will be called without the ap
 ```
 
 and the text data that the user typed would be located in `data.additionalData.inlineReply`.
+
+**Note:** On Android M and earlier the above in line behavior is not supported. As a fallback when `inline` is set to `true` the `foreground` setting will be changed to the default `true` setting. This allows your app to be launched from a closed state into the foreground where any behavior desired as a result of the user selecting the in line reply action button can be handled through the associated `callback`.
 
 #### Attributes
 

--- a/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
+++ b/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
@@ -48,11 +48,10 @@ public class PushHandlerActivity extends Activity implements PushConstants {
         finish();
 
         Log.d(LOG_TAG, "isPushPluginActive = " + isPushPluginActive);
-
         if (!isPushPluginActive && foreground && inline) {
             Log.d(LOG_TAG, "forceMainActivityReload");
             forceMainActivityReload(false);
-        } else if(startOnBackground) {
+        } else if(startOnBackground || inline && android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.N) {
             forceMainActivityReload(true);
         } else {
             Log.d(LOG_TAG, "don't want main activity");

--- a/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
+++ b/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
@@ -40,10 +40,18 @@ public class PushHandlerActivity extends Activity implements PushConstants {
             notificationManager.cancel(GCMIntentService.getAppName(this), notId);
         }
 
-        Log.d(LOG_TAG, "bringToForeground = " + foreground);
-
         boolean isPushPluginActive = PushPlugin.isActive();
         boolean inline = processPushBundle(isPushPluginActive, intent);
+
+        Log.d(LOG_TAG, "LessThanAndroidN: " + android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.N);
+        Log.d(LOG_TAG, "inlineValue: " + inline);
+
+        if(inline && android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.N){
+                    Log.d(LOG_TAG, "BradsConditionTrue");
+                    boolean foreground = true;
+        }
+
+        Log.d(LOG_TAG, "bringToForeground = " + foreground);
 
         finish();
 
@@ -51,7 +59,8 @@ public class PushHandlerActivity extends Activity implements PushConstants {
         if (!isPushPluginActive && foreground && inline) {
             Log.d(LOG_TAG, "forceMainActivityReload");
             forceMainActivityReload(false);
-        } else if(startOnBackground || inline && android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.N) {
+        } else if(startOnBackground) {
+            Log.d(LOG_TAG, "startOnBackgroundTrue");
             forceMainActivityReload(true);
         } else {
             Log.d(LOG_TAG, "don't want main activity");
@@ -66,7 +75,7 @@ public class PushHandlerActivity extends Activity implements PushConstants {
         Bundle extras = getIntent().getExtras();
         Bundle remoteInput = null;
 
-        if (extras != null)	{
+        if (extras != null) {
             Bundle originalExtras = extras.getBundle(PUSH_BUNDLE);
 
             originalExtras.putBoolean(FOREGROUND, false);

--- a/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
+++ b/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
@@ -44,8 +44,7 @@ public class PushHandlerActivity extends Activity implements PushConstants {
         boolean inline = processPushBundle(isPushPluginActive, intent);
 
         if(inline && android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.N){
-                    Log.d(LOG_TAG, "BradsConditionTrue");
-                    foreground = true;
+            foreground = true;
         }
 
         Log.d(LOG_TAG, "bringToForeground = " + foreground);

--- a/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
+++ b/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
@@ -43,9 +43,6 @@ public class PushHandlerActivity extends Activity implements PushConstants {
         boolean isPushPluginActive = PushPlugin.isActive();
         boolean inline = processPushBundle(isPushPluginActive, intent);
 
-        Log.d(LOG_TAG, "LessThanAndroidN: " + (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.N));
-        Log.d(LOG_TAG, "inlineValue: " + inline);
-
         if(inline && android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.N){
                     Log.d(LOG_TAG, "BradsConditionTrue");
                     foreground = true;

--- a/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
+++ b/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
@@ -43,7 +43,7 @@ public class PushHandlerActivity extends Activity implements PushConstants {
         boolean isPushPluginActive = PushPlugin.isActive();
         boolean inline = processPushBundle(isPushPluginActive, intent);
 
-        Log.d(LOG_TAG, "LessThanAndroidN: " + Integer.toString(android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.N));
+        Log.d(LOG_TAG, "LessThanAndroidN: " + (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.N));
         Log.d(LOG_TAG, "inlineValue: " + inline);
 
         if(inline && android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.N){

--- a/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
+++ b/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
@@ -43,12 +43,12 @@ public class PushHandlerActivity extends Activity implements PushConstants {
         boolean isPushPluginActive = PushPlugin.isActive();
         boolean inline = processPushBundle(isPushPluginActive, intent);
 
-        Log.d(LOG_TAG, "LessThanAndroidN: " + android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.N);
+        Log.d(LOG_TAG, "LessThanAndroidN: " + Integer.toString(android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.N));
         Log.d(LOG_TAG, "inlineValue: " + inline);
 
         if(inline && android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.N){
                     Log.d(LOG_TAG, "BradsConditionTrue");
-                    boolean foreground = true;
+                    foreground = true;
         }
 
         Log.d(LOG_TAG, "bringToForeground = " + foreground);


### PR DESCRIPTION
## Description
In `PushHandlerActivity.Java` I added a condition if `inline` is set to `true` but the client Android version was below N then the `foreground` should always be set to `true`. 

## Related Issue
#1446

## Motivation and Context
When trying to add inline reply to support Android N and later, clients running earlier versions of Android would not have their inline action callback ran. 

This left the notification's action button appearing as it did nothing.

## How Has This Been Tested?
Checked to ensure app handled notifications from closed, background and foreground as expected. App was launched to foreground when in the closed or background state. 
Tested on the following device & environment;
#### Platform and Version
     Android 5.0.2

#### What device vendor 
    Oneplus One

#### Cordova CLI version and cordova platform version
    cordova --version                          6.4
    cordova platform version android           6.1
    cordova platform version ios           4.3

#### Plugin version
    cordova plugin version | grep phonegap-plugin-push   1.9.1

I don't have a Android device running Android N to test on. So no tests have been ran for that version.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
