### PR TITLE
:penguin: android mixpanel pushnotification suport added

### DIFF
--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -168,7 +168,7 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
      * Replace alternate keys with our canonical value
      */
     private String normalizeKey(String key) {
-        if (key.equals(BODY) || key.equals(ALERT) || key.equals(GCM_NOTIFICATION_BODY) || key.equals(TWILIO_BODY)) {
+        if (key.equals(BODY) || key.equals(ALERT) || key.equals(MP_MESSAGE) || key.equals(GCM_NOTIFICATION_BODY) || key.equals(TWILIO_BODY)) {
             return MESSAGE;
         } else if (key.equals(TWILIO_TITLE)) {
             return TITLE;

--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -67,6 +67,7 @@ public interface PushConstants {
     public static final String TWILIO_BODY = "twi_body";
     public static final String TWILIO_TITLE = "twi_title";
     public static final String TWILIO_SOUND = "twi_sound";
+    public static final String MP_MESSAGE = "mp_message";
     public static final String START_IN_BACKGROUND = "cdvStartInBackground";
     public static final String FORCE_START = "force-start";
 }


### PR DESCRIPTION
## mixpanel pushnotification support.
Android app build with phonegap-plugin-push is not optimized to receive the default, web-app generated Mixpanel pushes. 
For the notification to appear on Android devices, currently one needs to include a custom payload in Mixpanels "Custom Data":
{
"title":"Title",
"body":"Content"
}
![issue](https://cloud.githubusercontent.com/assets/3897387/21880311/4635900a-d8c4-11e6-986a-9c3db1f7e02f.PNG)

This is an error prone step for any non-technical using Mixpanel to send notifications.

<!--- Describe your changes in detail -->
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
To Receive notifications from mixpanel with out the need for using the json format like above, i need to modify two files in the plugin.

## How Has This Been Tested?
Tested Android app by pushing notifications from mixpanel with out using custom JSON format.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.