### PR TITLE
Added VAPID key support

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -54,6 +54,7 @@ Attribute | Type | Default | Description
 Attribute | Type | Default | Description
 --------- | ---- | ------- | -----------
 `browser.pushServiceURL` | `string` | `http://push.api.phonegap.com/v1/push` | Optional. URL for the push server you want to use.
+`browser.applicationServerKey` | `string` | `` | Optional. Your GCM API key if you are using VAPID keys.
 
 #### iOS
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I added the possibility to pass a server key in the `init` method which is passed to the `pushManager.subscribe` method.

## Related Issue
#1140 

## Motivation and Context
I want to use the GCM push server for my browser app.

## How Has This Been Tested?
Tested in my app. If the server key is passed there is no need to post the subscribtion to the optinal given `pushServiceURL` so I won't execute that part of the code if an server key is given.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
