### PR TITLE
:sparkles: Adding support for AppCelerator push service

### DIFF
--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -229,6 +229,21 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
                         Log.e(LOG_TAG, "normalizeExtras: JSON exception");
                     }
                 }
+            } else if (key.equals(APPCELERATOR_PAYLOAD)) {
+                try {
+                    String json = extras.getString(key);
+                    JSONObject data = new JSONObject((String) json);
+                    JSONObject android = data.getJSONObject(ANDROID);
+
+                    newExtras.putString(MESSAGE, android.getString(ALERT));
+                    newExtras.putString(TITLE, android.getString(TITLE));
+                    newExtras.putString(ICON, android.getString(ICON));
+                    newExtras.putBoolean(FOREGROUND, false);
+                    newExtras.putBoolean(COLDSTART, PushPlugin.isActive());
+                }
+                catch(JSONException ex) {
+                    Log.d(LOG_TAG, "Error getting alert and/or title from inner payload from Appcelerator");
+                }
             } else if (key.equals(("notification"))) {
                 Bundle value = extras.getBundle(key);
                 Iterator<String> iterator = value.keySet().iterator();

--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -70,4 +70,5 @@ public interface PushConstants {
     public static final String MP_MESSAGE = "mp_message";
     public static final String START_IN_BACKGROUND = "cdvStartInBackground";
     public static final String FORCE_START = "force-start";
+    public static final String APPCELERATOR_PAYLOAD = "payload";
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I created a logic so that the plugin can understand the payload sent by appcelerator platform.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/phonegap/phonegap-plugin-push/issues/1594

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Our customer uses appcelerator platform to send push notifications to their users. We need this compatibility in order to receive these pushes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on the device running forked version of repository. Pushes were sent via Postman calling Appcelerator API and also calling GCM directly. No issues found.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
