### PR TITLE
Add no-cache flag to payload

### DIFF
--- a/docs/PAYLOAD.md
+++ b/docs/PAYLOAD.md
@@ -17,6 +17,7 @@
   - [Picture Messages](#picture-messages)
   - [Background Notifications](#background-notifications)
     - [Use of content-available: true](#use-of-content-available-true)
+  - [Caching](#caching)
   - [Huawei and Xiaomi Phones](#huawei-and-xiaomi-phones)
   - [Application force closed](#application-force-closed)
   - [Visibility](#visibility-of-notifications)
@@ -1070,6 +1071,22 @@ service.send(message, { registrationTokens: [ deviceID ] }, function (err, respo
 	if(err) console.error(err);
 	else 	console.log(response);
 });
+```
+
+### Caching
+
+By default, when a notification arrives and 'content-available' is set to '1', the plugin will try to deliver the data payload even if the app is not running. In that case, the payload is cached and may be delivered when the app is started again. To disable this behavior, you can set a `no-cache` flag in the notification payload. 0: caching enabled (default), 1: caching disabled.
+
+```javascript
+{
+    "registration_ids": ["my device id"],
+    "data": {
+        "title": "Push without cache",
+        "message": "When the app is closed, this notification will not be cached",
+        "content-available": "1",
+        "no-cache": "1"
+    }
+}
 ```
 
 ## Visibility of Notifications

--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -70,4 +70,5 @@ public interface PushConstants {
     public static final String MP_MESSAGE = "mp_message";
     public static final String START_IN_BACKGROUND = "cdvStartInBackground";
     public static final String FORCE_START = "force-start";
+    public static final String NO_CACHE = "no-cache";
 }

--- a/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
+++ b/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
@@ -77,6 +77,7 @@ public class PushHandlerActivity extends Activity implements PushConstants {
             originalExtras.putBoolean(FOREGROUND, false);
             originalExtras.putBoolean(COLDSTART, !isPushPluginActive);
             originalExtras.putString(ACTION_CALLBACK, extras.getString(CALLBACK));
+            originalExtras.remove(NO_CACHE);
 
             remoteInput = RemoteInput.getResultsFromIntent(intent);
             if (remoteInput != null) {

--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -259,13 +259,14 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
 
     /*
      * Sends the pushbundle extras to the client application.
-     * If the client application isn't currently active, it is cached for later processing.
+     * If the client application isn't currently active and the no-cache flag is not set, it is cached for later processing.
      */
     public static void sendExtras(Bundle extras) {
         if (extras != null) {
+            String noCache = extras.getString(NO_CACHE);
             if (gWebView != null) {
                 sendEvent(convertBundleToJson(extras));
-            } else {
+            } else if(!"1".equals(noCache)){
                 Log.v(LOG_TAG, "sendExtras: caching extras to send at a later time.");
                 gCachedExtras.add(extras);
             }


### PR DESCRIPTION
## Description
Add no-cache flag to payload, with default value '0'

## Related Issue
Issue #1617 

## Motivation and Context
According to the payload flowchart and the text beneath it, when the plugin receives the notification with content-available set to 1 and the app is not running (force-closed), no further processing should occur.

In the above situation, the payload is cached and sent to the app on initialisation.

While this could be intended behavior, with the current code there is no method to prevent the caching if you want to. This flag add a way to prevent it.

## How Has This Been Tested?
Only tested in local development environment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
