### PR TITLE
Add dismiss key to on notification data

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -203,6 +203,7 @@ Parameter | Type | Description
 `data.additionalData` | `Object` | An optional collection of data sent by the 3rd party push service that does not fit in the above properties.
 `data.additionalData.foreground` | `boolean` | Whether the notification was received while the app was in the foreground
 `data.additionalData.coldstart` | `boolean` | Will be `true` if the application is started by clicking on the push notification, `false` if the app is already started.
+`data.additionalData.dismissed` | `boolean` | Is set to `true` if the notification was dismissed by the user
 
 ### Example
 

--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -331,12 +331,19 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
         int requestCode = new Random().nextInt();
         PendingIntent contentIntent = PendingIntent.getActivity(this, requestCode, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT);
 
+        Intent dismissedNotificationIntent = new Intent(notificationIntent);
+        dismissedNotificationIntent.putExtra(DISMISSED, true);
+
+        requestCode = new Random().nextInt();
+        PendingIntent deleteIntent = PendingIntent.getActivity(this, requestCode, dismissedNotificationIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+
         NotificationCompat.Builder mBuilder =
                 new NotificationCompat.Builder(context)
                         .setWhen(System.currentTimeMillis())
                         .setContentTitle(fromHtml(extras.getString(TITLE)))
                         .setTicker(fromHtml(extras.getString(TITLE)))
                         .setContentIntent(contentIntent)
+                        .setDeleteIntent(deleteIntent)
                         .setAutoCancel(true);
 
         SharedPreferences prefs = context.getSharedPreferences(PushPlugin.COM_ADOBE_PHONEGAP_PUSH, Context.MODE_PRIVATE);

--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -70,4 +70,5 @@ public interface PushConstants {
     public static final String MP_MESSAGE = "mp_message";
     public static final String START_IN_BACKGROUND = "cdvStartInBackground";
     public static final String FORCE_START = "force-start";
+    public static final String DISMISSED = "dismissed";
 }

--- a/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
+++ b/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
@@ -34,6 +34,8 @@ public class PushHandlerActivity extends Activity implements PushConstants {
         Log.d(LOG_TAG, "callback = " + callback);
         boolean foreground = getIntent().getExtras().getBoolean("foreground", true);
         boolean startOnBackground = getIntent().getExtras().getBoolean(START_IN_BACKGROUND, false);
+        boolean dismissed = getIntent().getExtras().getBoolean(DISMISSED, false);
+        Log.d(LOG_TAG, "dismissed = " + dismissed);
 
         if(!startOnBackground){
             NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
@@ -51,15 +53,17 @@ public class PushHandlerActivity extends Activity implements PushConstants {
 
         finish();
 
-        Log.d(LOG_TAG, "isPushPluginActive = " + isPushPluginActive);
-        if (!isPushPluginActive && foreground && inline) {
-            Log.d(LOG_TAG, "forceMainActivityReload");
-            forceMainActivityReload(false);
-        } else if(startOnBackground) {
-            Log.d(LOG_TAG, "startOnBackgroundTrue");
-            forceMainActivityReload(true);
-        } else {
-            Log.d(LOG_TAG, "don't want main activity");
+        if(!dismissed) {
+            Log.d(LOG_TAG, "isPushPluginActive = " + isPushPluginActive);
+            if (!isPushPluginActive && foreground && inline) {
+                Log.d(LOG_TAG, "forceMainActivityReload");
+                forceMainActivityReload(false);
+            } else if(startOnBackground) {
+                Log.d(LOG_TAG, "startOnBackgroundTrue");
+                forceMainActivityReload(true);
+            } else {
+                Log.d(LOG_TAG, "don't want main activity");
+            }
         }
     }
 
@@ -76,6 +80,7 @@ public class PushHandlerActivity extends Activity implements PushConstants {
 
             originalExtras.putBoolean(FOREGROUND, false);
             originalExtras.putBoolean(COLDSTART, !isPushPluginActive);
+            originalExtras.putBoolean(DISMISSED, extras.getBoolean(DISMISSED));
             originalExtras.putString(ACTION_CALLBACK, extras.getString(CALLBACK));
 
             remoteInput = RemoteInput.getResultsFromIntent(intent);

--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -420,6 +420,9 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
                 else if (key.equals(FOREGROUND)) {
                     additionalData.put(key, extras.getBoolean(FOREGROUND));
                 }
+                else if (key.equals(DISMISSED)) {
+                    additionalData.put(key, extras.getBoolean(DISMISSED));
+                }
                 else if ( value instanceof String ) {
                     String strValue = (String)value;
                     try {


### PR DESCRIPTION
## Description
Add dismiss key when user swipes notification from shade (Android only)

## Related Issue
Fixes issue #1596 

## Motivation and Context
There is currently no way to detect if the user dismissed the notification

## How Has This Been Tested?
Local development only

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
