### PR TITLE
Android 4.1.2 - hasPermission fails

### DIFF
--- a/src/android/com/adobe/phonegap/push/PermissionUtils.java
+++ b/src/android/com/adobe/phonegap/push/PermissionUtils.java
@@ -10,8 +10,12 @@ import java.lang.reflect.Method;
 public class PermissionUtils {
 
     private static final String CHECK_OP_NO_THROW = "checkOpNoThrow";
+    private static final int MIN_API_LEVEL = 19; // required by AppOpsManager
 
     public static boolean hasPermission(Context appContext, String appOpsServiceId) throws UnknownError {
+        if (android.os.Build.VERSION.SDK_INT < MIN_API_LEVEL) {
+            return true;
+        }
 
         ApplicationInfo appInfo = appContext.getApplicationInfo();
 


### PR DESCRIPTION
## Description

The class AppOpsManager is not available for Android API level less than 19.
For earlier Android versions, the value is always true, since the user can not deny this permission. 

## Related Issue
This solves the issue [807 - Android 4.1.2 - hasPermission fails. PermissionUtils.java throws ClassNotFoundException](https://github.com/phonegap/phonegap-plugin-push/issues/807)

## Motivation and Context
Currently, for earlier android versions, the plugin's "getPermission" method calls the error callback with the message "class not found".

## How Has This Been Tested?
Tested this on:
* Samsung Nexus S, Android 4.1.2, API 16
* LGE Nexus 5, Android 7.1.1, API 25

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
