### PR TITLE
Fix issue #1663 by allowing "message" as the data payload key

### DIFF
--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -253,11 +253,16 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
                     newExtras.putString(newKey, valueData);
                 }
                 continue;
+            // In case we weren't working on the payload data node or the notification node,
+            // normalize the key.
+            // This allows to have "message" as the payload data key without colliding
+            // with the other "message" key (holding the body of the payload)
+            // See issue #1663
+            } else {
+                String newKey = normalizeKey(key, messageKey, titleKey);
+                Log.d(LOG_TAG, "replace key " + key + " with " + newKey);
+                replaceKey(context, key, newKey, extras, newExtras);
             }
-
-            String newKey = normalizeKey(key, messageKey, titleKey);
-            Log.d(LOG_TAG, "replace key " + key + " with " + newKey);
-            replaceKey(context, key, newKey, extras, newExtras);
 
         } // while
 


### PR DESCRIPTION
## Description
When receiving a message on Android, the normalizeExtras method tries to normalize each section in the following order:
1 If the key is holding the payload data structure
2 If the key is holding the notification data structure
3 For other keys

The problem was that 1/2 and 3 were not exclusive, the normalization process for "other key" (3) could happen just after the process for "payload data" (1). Which caused problems in case the same key "message" is used.

With this PR, the after the normalization process ran on the payload data, it won't try to normalize again the same key, erasing the previous value.

## Related Issue
Issue #1663

## Motivation and Context
It allows to have "message" as the payload data key. It is not standard, but it is used by some push services.

## How Has This Been Tested?
I tested the change on my device, with my "faulty" push service.
The changes are very limited so I'm very confident there won't be any side effects.

## Screenshots (if appropriate):
![screenshot_20170404-093949](https://cloud.githubusercontent.com/assets/7261426/24646053/c941af60-191a-11e7-953c-4bf30dcb6fc4.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.