### PR TITLE
Shortened log tag PushPlugin_BackgroundActionButtonHandler to bring u…

### DIFF
--- a/src/android/com/adobe/phonegap/push/BackgroundActionButtonHandler.java
+++ b/src/android/com/adobe/phonegap/push/BackgroundActionButtonHandler.java
@@ -9,7 +9,7 @@ import android.util.Log;
 import android.support.v4.app.RemoteInput;
 
 public class BackgroundActionButtonHandler extends BroadcastReceiver implements PushConstants {
-    private static String LOG_TAG = "PushPlugin_BackgroundActionButtonHandler";
+    private static String LOG_TAG = "ActionButtonHandler";
 
     @Override
     public void onReceive(Context context, Intent intent) {

--- a/src/android/com/adobe/phonegap/push/BackgroundActionButtonHandler.java
+++ b/src/android/com/adobe/phonegap/push/BackgroundActionButtonHandler.java
@@ -9,7 +9,7 @@ import android.util.Log;
 import android.support.v4.app.RemoteInput;
 
 public class BackgroundActionButtonHandler extends BroadcastReceiver implements PushConstants {
-    private static String LOG_TAG = "ActionButtonHandler";
+    private static String LOG_TAG = "PushPlugin_BGActionBtn";
 
     @Override
     public void onReceive(Context context, Intent intent) {

--- a/src/android/com/adobe/phonegap/push/BackgroundActionButtonHandler.java
+++ b/src/android/com/adobe/phonegap/push/BackgroundActionButtonHandler.java
@@ -9,7 +9,7 @@ import android.util.Log;
 import android.support.v4.app.RemoteInput;
 
 public class BackgroundActionButtonHandler extends BroadcastReceiver implements PushConstants {
-    private static String LOG_TAG = "PushPlugin_BGActionBtn";
+    private static String LOG_TAG = "Push_BGActionButton";
 
     @Override
     public void onReceive(Context context, Intent intent) {

--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -46,7 +46,7 @@ import java.util.Random;
 @SuppressLint("NewApi")
 public class GCMIntentService extends GcmListenerService implements PushConstants {
 
-    private static final String LOG_TAG = "PushPlugin_GCMIntentService";
+    private static final String LOG_TAG = "Push_GCMIntentService";
     private static HashMap<Integer, ArrayList<String>> messageMap = new HashMap<Integer, ArrayList<String>>();
 
     public void setNotification(int notId, String message){

--- a/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
+++ b/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
@@ -11,7 +11,7 @@ import android.support.v4.app.RemoteInput;
 
 
 public class PushHandlerActivity extends Activity implements PushConstants {
-    private static String LOG_TAG = "PushPlugin_PushHandlerActivity";
+    private static String LOG_TAG = "Push_HandlerActivity";
 
     /*
      * this activity will be started if the user touches a notification that we own.

--- a/src/android/com/adobe/phonegap/push/PushInstanceIDListenerService.java
+++ b/src/android/com/adobe/phonegap/push/PushInstanceIDListenerService.java
@@ -13,7 +13,7 @@ import org.json.JSONException;
 import java.io.IOException;
 
 public class PushInstanceIDListenerService extends InstanceIDListenerService implements PushConstants {
-    public static final String LOG_TAG = "PushPlugin_PushInstanceIDListenerService";
+    public static final String LOG_TAG = "Push_InstanceIDListener";
 
     @Override
     public void onTokenRefresh() {

--- a/src/android/com/adobe/phonegap/push/RegistrationIntentService.java
+++ b/src/android/com/adobe/phonegap/push/RegistrationIntentService.java
@@ -13,7 +13,7 @@ import com.google.android.gms.iid.InstanceID;
 import java.io.IOException;
 
 public class RegistrationIntentService extends IntentService implements PushConstants {
-    public static final String LOG_TAG = "PushPlugin_RegistrationIntentService";
+    public static final String LOG_TAG = "Push_RegistrationIntent";
 
     public RegistrationIntentService() {
         super(LOG_TAG);


### PR DESCRIPTION
## Description
Shortened log tag PushPlugin_BackgroundActionButtonHandler to bring under 23 character Lint requirement

## Related Issue
https://github.com/phonegap/phonegap-plugin-push/issues/1702

## Motivation and Context
I keep getting the error `The logging tag can be at most 23 characters, was 40 (PushPlugin_BackgroundActionButtonHandler)` when I build, making it impossible to use a lint check requirement in my build process. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
