### PR TITLE
Handle null in getCircleBitmap.

### DIFF
--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -706,6 +706,10 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
     }
 
     private Bitmap getCircleBitmap(Bitmap bitmap) {
+        if (bitmap == null) {
+            return null;
+        }
+        
         final Bitmap output = Bitmap.createBitmap(bitmap.getWidth(), bitmap.getHeight(), Bitmap.Config.ARGB_8888);
         final Canvas canvas = new Canvas(output);
         final int color = Color.RED;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Guarded logic creating a circle version of the passed bitmap against null refs. Returning null in this case.

## Related Issue
Fixes #1704 

## Motivation and Context
See #1704

## How Has This Been Tested?
Recompiled with change and followed steps from #1704 to make sure the crash is gone.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
