### PR TITLE
Fixes 'framework not found GoogleToolboxForMac' linker error in 2.0.0-rc3

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -84,6 +84,7 @@
     <header-file src="src/ios/AppDelegate+notification.h"/>
     <header-file src="src/ios/PushPlugin.h"/>
     <framework src="FirebaseMessaging" type="podspec" spec="~> 1.2.1"/>
+    <framework src="GoogleToolboxForMac" type="podspec" spec="~> 2.1.1"/>
     <resource-file src="src/ios/GoogleService-Info.plist" target="Resources/GoogleService-Info.plist"/>
   </platform>
   <platform name="windows">


### PR DESCRIPTION
## Description

`framework not found GoogleToolboxForMac` linker error encountered in v2.0.0-rc3. Adding the GoogleToolboxForMac cocoapod in plugin.xml fixes it.

## Motivation and Context

Make v2.0.0 work.

## How Has This Been Tested?

Tested with cordova-cli@7 and cordova-ios@4.4.0, success.

## Types of changes

One line in plugin.xml (GoogleToolboxForMac framework added)

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
