### PR TITLE
Remove resource-file tag

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -85,7 +85,6 @@
     <header-file src="src/ios/PushPlugin.h"/>
     <framework src="FirebaseMessaging" type="podspec" spec="~> 1.2.1"/>
     <framework src="GoogleToolboxForMac" type="podspec" spec="~> 2.1.1"/>
-    <resource-file src="src/ios/GoogleService-Info.plist" target="Resources/GoogleService-Info.plist"/>
   </platform>
   <platform name="windows">
     <js-module src="src/windows/PushPluginProxy.js" name="PushPlugin">


### PR DESCRIPTION
The resource-file tag was used to create the Resources folder with an empty GoogleService-Info.plist file easily so the hook could write on it, but as the hook is removed it doesn't make sense to keep the resource-file tag here

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
