### PR TITLE
Remove GTM framework.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -85,7 +85,6 @@
     <header-file src="src/ios/AppDelegate+notification.h"/>
     <header-file src="src/ios/PushPlugin.h"/>
     <framework src="FirebaseMessaging" type="podspec" spec="~> 1.2.1"/>
-    <framework src="GoogleToolboxForMac" type="podspec" spec="~> 2.1.1"/>
   </platform>
   <platform name="windows">
     <js-module src="src/windows/PushPluginProxy.js" name="PushPlugin">


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Remove GTM, since it includes unit testing code that uses Private API. GTM should already be downloaded by the FirebaseMessaging CocoaPod as a dependency.

## Related Issue

Issue #1736 

## Motivation and Context

Fix Apple App Store submission issue

## How Has This Been Tested?

Created a new project (cli 7), added this plugin v2.0.x, updated prov profiles in Xcode, build success.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [X] All new and existing tests passed.
