### PR TITLE
update FirebaseMessaging podspec

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -84,7 +84,7 @@
     <source-file src="src/ios/PushPlugin.m"/>
     <header-file src="src/ios/AppDelegate+notification.h"/>
     <header-file src="src/ios/PushPlugin.h"/>
-    <framework src="FirebaseMessaging" type="podspec" spec="~> 1.2.1"/>
+    <framework src="FirebaseMessaging" type="podspec" spec="~> 2.0.0"/>
   </platform>
   <platform name="windows">
     <js-module src="src/windows/PushPluginProxy.js" name="PushPlugin">


### PR DESCRIPTION
I have updated FirebaseMessaging podspec to 2.0.0 (latest), and it continues working.

Tested push notification with app open, background and closed. All of them in sandbox mode.
