### PR TITLE
V1.x Android: handle dismissed notifications

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -40,6 +40,7 @@
     <config-file target="AndroidManifest.xml" parent="/manifest/application">
       <activity android:name="com.adobe.phonegap.push.PushHandlerActivity" android:exported="true" android:permission="${applicationId}.permission.PushHandlerActivity"/>
       <receiver android:name="com.adobe.phonegap.push.BackgroundActionButtonHandler"/>
+      <receiver android:name="com.adobe.phonegap.push.PushDismissedHandler"/>
       <receiver android:name="com.google.android.gms.gcm.GcmReceiver" android:exported="true" android:permission="com.google.android.c2dm.permission.SEND">
         <intent-filter>
           <action android:name="com.google.android.c2dm.intent.RECEIVE"/>
@@ -70,6 +71,7 @@
     <source-file src="src/android/com/adobe/phonegap/push/RegistrationIntentService.java" target-dir="src/com/adobe/phonegap/push/"/>
     <source-file src="src/android/com/adobe/phonegap/push/PermissionUtils.java" target-dir="src/com/adobe/phonegap/push/"/>
     <source-file src="src/android/com/adobe/phonegap/push/BackgroundActionButtonHandler.java" target-dir="src/com/adobe/phonegap/push/"/>
+    <source-file src="src/android/com/adobe/phonegap/push/PushDismissedHandler.java" target-dir="src/com/adobe/phonegap/push/"/>
   </platform>
   <platform name="browser">
     <js-module src="www/browser/push.js" name="BrowserPush">

--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -348,11 +348,14 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
         int requestCode = new Random().nextInt();
         PendingIntent contentIntent = PendingIntent.getActivity(this, requestCode, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT);
 
-        Intent dismissedNotificationIntent = new Intent(notificationIntent);
+        Intent dismissedNotificationIntent = new Intent(this, PushDismissedHandler.class);
+        dismissedNotificationIntent.putExtra(PUSH_BUNDLE, extras);
+        dismissedNotificationIntent.putExtra(NOT_ID, notId);
         dismissedNotificationIntent.putExtra(DISMISSED, true);
+        dismissedNotificationIntent.setAction(PUSH_DISMISSED);
 
         requestCode = new Random().nextInt();
-        PendingIntent deleteIntent = PendingIntent.getActivity(this, requestCode, dismissedNotificationIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent deleteIntent = PendingIntent.getBroadcast(this, requestCode, dismissedNotificationIntent, PendingIntent.FLAG_CANCEL_CURRENT);
 
         NotificationCompat.Builder mBuilder =
                 new NotificationCompat.Builder(context)
@@ -360,7 +363,7 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
                         .setContentTitle(fromHtml(extras.getString(TITLE)))
                         .setTicker(fromHtml(extras.getString(TITLE)))
                         .setContentIntent(contentIntent)
-                        //.setDeleteIntent(deleteIntent)
+                        .setDeleteIntent(deleteIntent)
                         .setAutoCancel(true);
 
         SharedPreferences prefs = context.getSharedPreferences(PushPlugin.COM_ADOBE_PHONEGAP_PUSH, Context.MODE_PRIVATE);

--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -79,4 +79,5 @@ public interface PushConstants {
     public static final String IMAGE_TYPE_SQUARE = "square";
     public static final String IMAGE_TYPE_CIRCLE = "circle";
     public static final String SUBJECT = "subject";
+    public static final String PUSH_DISMISSED = "push_dismissed";
 }

--- a/src/android/com/adobe/phonegap/push/PushDismissedHandler.java
+++ b/src/android/com/adobe/phonegap/push/PushDismissedHandler.java
@@ -1,0 +1,25 @@
+package com.adobe.phonegap.push;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+
+public class PushDismissedHandler extends BroadcastReceiver implements PushConstants {
+    private static String LOG_TAG = "Push_DismissedHandler";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        Bundle extras = intent.getExtras();
+        GCMIntentService gcm = new GCMIntentService();
+        String action = intent.getAction();
+        int notID = intent.getIntExtra(NOT_ID, 0);
+
+        if (action.equals(PUSH_DISMISSED)) {
+            Log.d(LOG_TAG, "PushDismissedHandler = " + extras);
+            Log.d(LOG_TAG, "not id = " + notID);
+
+            gcm.setNotification(notID, "");
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
When a user dismisses notifications, you would expect them to go away. Currently when using Inbox style, previous notifications will be included, even though the user has dismissed the notification. This fix handles dismissed notifications, and clears the internal list.
## Related Issue

#1665

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With the related issue, originally the dismissal of the notification would result in the app opening which is obviously the incorrect way to handle this, but the "fix" applied was just to remove the deleteIntent altogether, which is also the incorrect way to handle this.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I sent a bunch of inbox style notifications with the same notId, dismissed the notification, then resent a bunch more. Checked to see if the previous dismissed notifications were gone. They were.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
