### PR TITLE
Only use GCM if IS_GCM_ENABLED is true in the google plist

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -290,12 +290,13 @@
         // Load the file content and read the data into arrays
         NSDictionary *dict = [[NSDictionary alloc] initWithContentsOfFile:path];
         fcmSenderId = [dict objectForKey:@"GCM_SENDER_ID"];
+        BOOL isGcmEnabled = [[dict valueForKey:@"IS_GCM_ENABLED"] boolValue];
 
         NSLog(@"FCM Sender ID %@", fcmSenderId);
 
         //  GCM options
         [self setFcmSenderId: fcmSenderId];
-        if([[self fcmSenderId] length] > 0) {
+        if(isGcmEnabled && [[self fcmSenderId] length] > 0) {
             NSLog(@"Using FCM Notification");
             [self setUsesFCM: YES];
             dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
## Description
Added a check for IS_GCM_ENABLED from the GoogleService-Info.plist If the value is false, APNS will be used instead of FCM.

## Related Issue
https://github.com/phonegap/phonegap-plugin-push/issues/1770

## Motivation and Context
This prevents FCM being used when it has been disabled in the plist.

## How Has This Been Tested?
This has been tested locally in an existing Ionic project. All unit tests pass.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
