### PR TITLE
Android : Update for Push Notification with Big Image

### DIFF
--- a/src/android/com/adobe/phonegap/push/FCMService.java
+++ b/src/android/com/adobe/phonegap/push/FCMService.java
@@ -464,7 +464,12 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
          * Notification count
          */
         setVisibility(context, extras, mBuilder);
-
+      
+        /*
+         * Notification with big image
+         */
+        setNotificationBigImage(extras, mBuilder);
+      
         /*
          * Notification add actions
          */
@@ -799,7 +804,20 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
             }
         }
     }
+    
+    private void setNotificationBigImage(Bundle extras, NotificationCompat.Builder mBuilder) {
+        String bigImage = extras.getString(BIG_IMAGE); // from gcm
+        if (bigImage != null && !"".equals(bigImage)) {
+            if (bigImage.startsWith("http://") || bigImage.startsWith("https://")) {
+                Bitmap bitmap = getBitmapFromURL(bigImage);
 
+                mBuilder.setStyle(new NotificationCompat.BigPictureStyle()
+                    .bigPicture(bitmap));/*Notification with Image*/
+                Log.d(LOG_TAG, "using remote big-image from gcm");
+            }
+        }
+    }
+  
     private void setNotificationSmallIcon(Context context, Bundle extras, String packageName, Resources resources, NotificationCompat.Builder mBuilder, String localIcon) {
         int iconId = 0;
         String icon = extras.getString(ICON);


### PR DESCRIPTION
Option to set notifications with big picture.

<!--- Provide a general summary of your changes in the Title above -->

## Description
The Patch for generating large-format notifications that include a large image attachment. Here's how you'd set the BigPictureStyle on a notification:

You have to set **"big_image"** field in the data field of http request body like bellow,

```
{ 
   "data": {
       "big_image": "__IMAGE-URL__",
       "message": "Firebase Push Big Image Message Using API"
     },
    "to" : "__DEVICE-REGISTERATION-ID__"
}
```
## Screenshots:
![screenshot_2017-07-04-11-28-48](https://user-images.githubusercontent.com/16835868/27817125-1ec170d6-60ad-11e7-95e1-aa2d686f2ae5.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
