### PR TITLE
Add clearAllNotifications() to type definitions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -103,6 +103,13 @@ declare namespace PhonegapPluginPush {
 		 * @param id
 		 */
 		finish(successHandler?: () => any, errorHandler?: () => any, id?: string): void
+		
+		/**
+		 * Tells the OS to clear all notifications from the Notification Center
+		 * @param successHandler Is called when the api successfully clears the notifications.
+		 * @param errorHandler Is called when the api encounters an error when attempting to clears the notifications.
+		 */
+		clearAllNotifications(successHandler: () => any, errorHandler: () => any): void
 	}
 
 	/**


### PR DESCRIPTION
Adds the `clearAllNotifications()` function to the type definitions

## Related Issue
Fixes https://github.com/phonegap/phonegap-plugin-push/issues/1536

## Motivation and Context
Updates type definitions to match API changes

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)