### PR TITLE
:sparkles: Added `hasPermission` support for Windows platform.

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,7 +1,7 @@
 # API
 
 - [.init()](#pushnotificationinitoptions)
-- [.hasPermission() - Android & iOS only](#pushnotificationhaspermissionsuccesshandler---android--ios-only)
+- [.hasPermission()](#pushnotificationhaspermissionsuccesshandler)
 - [push.on()](#pushonevent-callback)
   - [push.on('registration')](#pushonregistration-callback)
   - [push.on('notification')](#pushonnotification-callback)
@@ -114,7 +114,7 @@ var push = PushNotification.init({
 });
 ```
 
-## PushNotification.hasPermission(successHandler) - Android & iOS only
+## PushNotification.hasPermission(successHandler)
 
 Checks whether the push notification permission has been granted.
 

--- a/src/windows/PushPluginProxy.js
+++ b/src/windows/PushPluginProxy.js
@@ -89,6 +89,11 @@ module.exports = {
             onFail(ex);
         }
     },
+    hasPermission: function (onSuccess) {
+        var notifier = Windows.UI.Notifications.ToastNotificationManager.createToastNotifier();
+
+        onSuccess({ isEnabled: !notifier.setting });
+    },
     subscribe: function() {
         console.log("Subscribe is unsupported");
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added support for the `hasPermission` function on the Windows platform.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1907

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To allow for checking of the push notification permission on the Windows platform.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Windows 10 - x64 architecture.
Called `PushNotification.hasPermission` first with notifications disabled, then again with notifications enabled.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
