### PR TITLE
Catch the execption when 'gcm_defaultSenderId' is not found in resources to prevent an app crash

### DIFF
--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.util.Log;
 
@@ -97,6 +98,10 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
                         callbackContext.error(e.getMessage());
                     } catch (IOException e) {
                         Log.e(LOG_TAG, "execute: Got IO Exception " + e.getMessage());
+                        callbackContext.error(e.getMessage());
+                    } catch (Resources.NotFoundException e) {
+
+                        Log.e(LOG_TAG, "execute: Got Resources NotFoundException " + e.getMessage());
                         callbackContext.error(e.getMessage());
                     }
 


### PR DESCRIPTION
Some users, I included, are affected by a bug when using FCM so that 'gcm_defaultSenderId' is not found, see #1800. This leads to the app crashing. This change does not fix the cause of the error, but at least it prevents the app from crashing by catching the relevant exception.

## Description
Catch the exception when 'gcm_defaultSenderId' is not found in the app's resources, for whatever reason, so that the app does not crash.

## Related Issue
#1800 

## Motivation and Context
Even if the root cause for this issue is found, an app should not crash "just" because a resource cannot be found.

## How Has This Been Tested?
I did run npm test and build my app with the changes in the plugin to verify that the app no longer crashes.

## Screenshots (if appropriate):

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.