### PR TITLE
:bug: Issue #1970: No custom sound plays when notification is forced in foreground.

### DIFF
--- a/src/android/com/adobe/phonegap/push/FCMService.java
+++ b/src/android/com/adobe/phonegap/push/FCMService.java
@@ -79,6 +79,9 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
         if (message.getNotification()!=null) {
             extras.putString(TITLE,message.getNotification().getTitle());
             extras.putString(MESSAGE,message.getNotification().getBody());
+            extras.putString(SOUND,message.getNotification().getSound());
+            extras.putString(ICON,message.getNotification().getIcon());
+            extras.putString(COLOR,message.getNotification().getColor());
         }
         for (Map.Entry<String, String> entry : message.getData().entrySet()) {
             extras.putString(entry.getKey(), entry.getValue());
@@ -427,7 +430,7 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
          * To use, add the `iconColor` key to plugin android options
          *
          */
-        setNotificationIconColor(extras.getString("color"), mBuilder, localIconColor);
+        setNotificationIconColor(extras.getString(COLOR), mBuilder, localIconColor);
 
         /*
          * Notification Icon

--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -32,6 +32,7 @@ public interface PushConstants {
     public static final String MESSAGE = "message";
     public static final String BODY = "body";
     public static final String SOUNDNAME = "soundname";
+    public static final String COLOR = "color";
     public static final String LED_COLOR = "ledColor";
     public static final String PRIORITY = "priority";
     public static final String IMAGE = "image";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
SOUND, ICON and COLOR values added from Notification to extras.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/phonegap/phonegap-plugin-push/issues/1970

## Motivation and Context
I have an app (taxi booking) with custom notification sound included and i will play this sound when app is in foreground too, but it works only when app is inactive. Otherwise default system notification sound plays.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Changes are simple and refs to [fcm documentation](https://developers.google.com/android/reference/com/google/firebase/messaging/RemoteMessage.Notification).
- My build with described changes works fine.
- Existing tests are ok.

## Screenshots (if appropriate):
- Sound plays :)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
