### PR TITLE
Remove duplicated action to unsubscribe topic

### DIFF
--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -471,10 +471,6 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
             for (int i=0; i<topics.length(); i++) {
                 topic = topics.optString(i, null);
                 unsubscribeFromTopic(topic, registrationToken);
-                if (topic != null) {
-                    Log.d(LOG_TAG, "Unsubscribing to topic: " + topic);
-                    FirebaseMessaging.getInstance().unsubscribeFromTopic(topic);
-                }
             }
         }
     }


### PR DESCRIPTION
## Description

There's no need to call the unsubscribe twice.

## Related Issue

PR for issue #1973

