### PR TITLE
Set the launch args correctly on windows

### DIFF
--- a/src/windows/PushPluginProxy.js
+++ b/src/windows/PushPluginProxy.js
@@ -66,7 +66,7 @@ module.exports = {
                     onSuccess(result, { keepCallback: true });
 
                     var context = cordova.require('cordova/platform').activationContext;
-                    var launchArgs = context ? context.args : null;
+                    var launchArgs = context ? (context.argument || context.args) : null;
                     if (launchArgs) {         //If present, app launched through push notification
                         var result = { message: '' };       //Added to identify callback as notification type in the API
                         result.launchArgs = launchArgs;


### PR DESCRIPTION
## Description
As per the [documentation](https://docs.microsoft.com/en-us/uwp/api/windows.applicationmodel.activation.toastnotificationactivatedeventargs), toast notifications have the `argument` property.

## Related Issue
#1975

## Motivation and Context
To have windows push notifications working good

## How Has This Been Tested?
Notification from the service

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
-  New feature (non-breaking change which adds functionality)
-  Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
-  My change requires a change to the documentation.
-  I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
