### PR TITLE
fixed issue #2061: Localization in message not working correctly.

### DIFF
--- a/src/android/com/adobe/phonegap/push/FCMService.java
+++ b/src/android/com/adobe/phonegap/push/FCMService.java
@@ -253,6 +253,11 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
                 newExtras.putString(jsonKey, value);
               }
             }
+            else if (data.has(LOC_KEY) || data.has(LOC_DATA)) {
+              String newKey = normalizeKey(key, messageKey, titleKey);
+              Log.d(LOG_TAG, "replace key " + key + " with " + newKey);
+              replaceKey(context, key, newKey, extras, newExtras);
+            }
           } catch (JSONException e) {
             Log.e(LOG_TAG, "normalizeExtras: JSON exception");
           }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This is a bug fix to issue #2061.

## Description
<!--- Describe your changes in detail -->

The code fragment checks for the presence of LOC_DATA or LOC_KEY in the json object.  If any of the keys are present,  it performs a replaceKey call like it did prior to PR#1666.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
#2061 
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
1.  Send a payload with
```
{
    "registration_ids": ["my device id"],
    "data": {
        "message": {"locKey": "push_message_fox", "locData": ["fox", "dog"]}
    }
}
```
2. Note that message is missing in the notification object after passing normalizeExtras method is called.
<!--- Please link to the issue here: -->
#2061 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This fixes the issue and localises the messages properly as per documentation in PAYLOAD.md

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I have sent the test payload as above, and received localised versions of message after the change.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.