### PR TITLE
Fix instructions in README about google-services.json

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -60,7 +60,7 @@ In the platform tag for Android add the resource-file tag:
 
 ```
 <platform name="android">
-  <resource-file src="google-services.json" target="google-services.json" />
+  <resource-file src="google-services.json" target="app/google-services.json" />
 </platform>
 ```
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -56,11 +56,19 @@ cordova plugin add https://github.com/phonegap/phonegap-plugin-push
 
 As of version 2.0.0 the SENDER_ID parameter has been removed at install time. Instead you put your google-services.json (Android) and/or GoogleService-Info.plist in the root folder of your project and then add the following lines into your config.xml.
 
-In the platform tag for Android add the resource-file tag:
+In the platform tag for Android add the following resource-file tag if you are using cordova-android 7.0 or greater:
 
 ```
 <platform name="android">
   <resource-file src="google-services.json" target="app/google-services.json" />
+</platform>
+```
+
+If you are using cordova-android 6.x or earlier, add the following resource-file tag:
+
+```
+<platform name="android">
+  <resource-file src="google-services.json" target="google-services.json" />
 </platform>
 ```
 


### PR DESCRIPTION
## Description
The README instructions for the target of the `google-services.json` file were incorrect.

## Related Issue
n/a

## Motivation and Context
It took me a while to figure it out and I wanted to save other people some time.

## How Has This Been Tested?
n/a

## Screenshots (if appropriate):

## Types of changes
README only change

## Checklist:
n/a readme only change
