### PR TITLE
Unregister token with firebase

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -119,8 +119,9 @@
             [pubSub unsubscribeFromTopic:topic];
         }
     } else {
-        [[UIApplication sharedApplication] unregisterForRemoteNotifications];
-        [self successWithMessage:command.callbackId withMsg:@"unregistered"];
+        [[FIRInstanceID instanceID] deleteIDWithHandler:^void(NSError *_Nullable error){
+            [self successWithMessage:command.callbackId withMsg:@"unregistered"];
+        }];
     }
 }
 


### PR DESCRIPTION
Solves https://github.com/phonegap/phonegap-plugin-push/issues/2130

## Description
Rather than disable the ability to receive notifications locally on the phone, we're actually unregistering the token with FCM.

## Motivation and Context
A user logs in, we save the token for that user, the user logs out so we call unregister. A new user logs in. These two users should not be sharing the same push notification token.

## How Has This Been Tested?
I used this code with my app. Logged in as a user, was able to receive notifications, called unregister on logout, attempted to send a message to that same token and received a `messaging/registration-token-not-registered` error message on the server and never received the message on the phone.

## Types of changes
This isn't really a breaking change for the plugin, but it is logically different in terms of application code that uses this plugin. They may start to see these unregistered errors. They also can't expect to unregister and then re-init and keep the same token. But I don't imagine these are reasonable expectations.

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
