### PR TITLE
🐛 Issue #2052: ServiceWorker.js Folder Instead of File

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,7 @@
   },
   "cordova": {
     "id": "phonegap-plugin-push",
-    "platforms": [
-      "ios",
-      "android",
-      "windows",
-      "browser"
-    ]
+    "platforms": ["ios", "android", "windows", "browser"]
   },
   "keywords": [
     "ecosystem:cordova",
@@ -52,9 +47,10 @@
         "cordova-android": ">=6.3.0",
         "cordova": ">=7.1.0"
       },
-      "2.1.2": {
+      ">=2.1.2": {
         "cordova-ios": ">=4.5.0",
         "cordova-android": ">=6.3.0",
+        "cordova-browser": ">=5.0.3",
         "cordova": ">=7.1.0"
       }
     }

--- a/plugin.xml
+++ b/plugin.xml
@@ -13,6 +13,7 @@
   <engines>
     <engine name="cordova" version=">=7.1.0"/>
     <engine name="cordova-android" version=">=6.3.0"/>
+    <engine name="cordova-browser" version=">=5.0.3"/>
     <engine name="cordova-ios" version=">=4.5.0"/>
   </engines>
   <platform name="android">


### PR DESCRIPTION
Trying to update plugin.xml/package.json to require at least cordova-plugin 5.0.3 or greater.

However, when I do I get the following error:

```
Installing "phonegap-plugin-push" for browser
(node:7614) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): code: engine.platform or engine.scriptSrc is not defined in custom engine "cordova-browser" from plugin "phonegap-plugin-push" for browser warn
```

looking into the code I think the root cause of the problem is that there is no `cordova-browser` in:

https://github.com/apache/cordova-lib/blob/master/src/plugman/util/default-engines.js

Why?