### PR TITLE
:sparkles: :penguin: Added playback with the schema "SCHEME_CONTENT" on Android

### DIFF
--- a/src/android/com/adobe/phonegap/push/FCMService.java
+++ b/src/android/com/adobe/phonegap/push/FCMService.java
@@ -726,9 +726,13 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
     }
     if (SOUND_RINGTONE.equals(soundname)) {
       mBuilder.setSound(android.provider.Settings.System.DEFAULT_RINGTONE_URI);
-    } else if (soundname != null && !soundname.contentEquals(SOUND_DEFAULT)) {
+    } else if (soundname != null && !soundname.contentEquals(SOUND_DEFAULT) && !soundname.contains(ContentResolver.SCHEME_CONTENT + ":")) {
       Uri sound = Uri
           .parse(ContentResolver.SCHEME_ANDROID_RESOURCE + "://" + context.getPackageName() + "/raw/" + soundname);
+      Log.d(LOG_TAG, sound.toString());
+      mBuilder.setSound(sound);
+    } else if (soundname.contains(ContentResolver.SCHEME_CONTENT + ":")){
+      Uri sound = Uri.parse(soundname);
       Log.d(LOG_TAG, sound.toString());
       mBuilder.setSound(sound);
     } else {


### PR DESCRIPTION
## Description
Added playback with the schema "SCHEME_CONTENT" on Android

## Related Issue

## Motivation and Context
Plugin Native Ringtones [(https://github.com/TongZhangzt/cordova-plugin-native-ringtones)](https://github.com/TongZhangzt/cordova-plugin-native-ringtones) return list of ringtones with the schema "SCHEME_CONTENT"

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
