### PR TITLE
Adding PushNotification.hasPermission() support in browsers

### DIFF
--- a/www/browser/push.js
+++ b/www/browser/push.js
@@ -367,7 +367,10 @@ module.exports = {
     },
 
     hasPermission: function(successCallback, errorCallback) {
-        successCallback(true);
+        const granted = Notification && Notification.permission === 'granted';
+        successCallback({
+            isEnabled: granted
+        });
     },
 
     unregister: function(successCallback, errorCallback, options) {


### PR DESCRIPTION
As discussed in. #2230, this PR adds support for the `hasPermission()` method in the browser.

## Description

The PR adds a basic implementation of `hasPermission()` that returns `{ isEnabled: true }` if `Notification` is in the global scope and `Notification.permission` is equal to `'granted'`.

## Related Issue

#2230

## Motivation and Context

Without this PR, `PushNotification.hasPermission()` returns `true`, which is not conformant to the documentation of `hasPermission()` as it is expected to return an object having an `isEnabled` key.

## How Has This Been Tested?

Manual testing in Google Chrome and Mozilla Firefox.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All existing tests passed.
