### PR TITLE
:ambulance: Bump com.android.support:support-v13 to v27 to avoid android multiple dex files error

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -38,7 +38,7 @@
         </intent-filter>
       </service>
     </config-file>
-    <framework src="com.android.support:support-v13:26.+"/>
+    <framework src="com.android.support:support-v13:27.+"/>
     <framework src="me.leolin:ShortcutBadger:1.1.17@aar"/>
     <framework src="com.google.firebase:firebase-messaging:$FCM_VERSION"/>
     <framework src="push.gradle" custom="true" type="gradleReference"/>


### PR DESCRIPTION
Description
The PR bumps the version of the Android support-v13 library to v27 to avoid the following Android build error:

```shell
platforms/android/gradlew: Command failed with exit code 1 Error output:
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
Dex: Error converting bytecode to dex:
Cause: com.android.dex.DexException: Multiple dex files define Landroid/support/v13/app/FragmentTabHost;
    UNEXPECTED TOP-LEVEL EXCEPTION:
    com.android.dex.DexException: Multiple dex files define Landroid/support/v13/app/FragmentTabHost;
    
com.android.dex.DexException: Multiple dex files define Landroid/support/v13/app/FragmentTabHost;
	at com.android.dx.merge.DexMerger.readSortableTypes(DexMerger.java:661)
	at com.android.dx.merge.DexMerger.getSortedTypes(DexMerger.java:616)
	at com.android.dx.merge.DexMerger.mergeClassDefs(DexMerger.java:598)
	at com.android.dx.merge.DexMerger.mergeDexes(DexMerger.java:171)
	at com.android.dx.merge.DexMerger.merge(DexMerger.java:198)
	at com.android.builder.dexing.DexArchiveMergerCallable.call(DexArchiveMergerCallable.java:61)
	at com.android.builder.dexing.DexArchiveMergerCallable.call(DexArchiveMergerCallable.java:36)
	at java.util.concurrent.ForkJoinTask$AdaptedCallable.exec(ForkJoinTask.java:1424)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':transformDexArchiveWithDexMergerForDebug'.
> com.android.build.api.transform.TransformException: com.android.dex.DexException: Multiple dex files define Landroid/support/v13/app/FragmentTabHost;

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

* Get more help at https://help.gradle.org

BUILD FAILED in 8s

```
Related Issue
#2229

Motivation and Context
Without this PR, the Android build fails completely when using this plugin with the [phonegap-plugin-barcodescanner](https://github.com/phonegap/phonegap-plugin-barcodescanner).

How Has This Been Tested?
Manual testing with `cordova 7.1.0`, `cordova-android 6.4.0`, `phonegap-plugin-barcodescanner 6.0.8`.

Types of changes
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
Checklist:
 - [x] My code follows the code style of this project.
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
 - [x] I have read the CONTRIBUTING document.
 - [ ] I have added tests to cover my changes.
 - [x] All existing tests passed.