### PR TITLE
Android fix to check if the channel is setup.

### DIFF
--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -129,18 +129,24 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
 
   @TargetApi(26)
   private void createDefaultNotificationChannelIfNeeded(JSONObject options) {
+    String id;
     // only call on Android O and above
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       final NotificationManager notificationManager = (NotificationManager) cordova.getActivity()
           .getSystemService(Context.NOTIFICATION_SERVICE);
       List<NotificationChannel> channels = notificationManager.getNotificationChannels();
-      if (channels.size() == 0) {
-        NotificationChannel mChannel = new NotificationChannel(DEFAULT_CHANNEL_ID, "PhoneGap PushPlugin",
-            NotificationManager.IMPORTANCE_DEFAULT);
-        mChannel.enableVibration(options.optBoolean(VIBRATE, true));
-        mChannel.setShowBadge(true);
-        notificationManager.createNotificationChannel(mChannel);
+      
+      for (int i=0; i<channels.size(); i++ ) {
+        id = channels.get(i).getId();
+        if (id.equals(DEFAULT_CHANNEL_ID)) {
+          return;
+        }
       }
+      NotificationChannel mChannel = new NotificationChannel(DEFAULT_CHANNEL_ID, "PhoneGap PushPlugin",
+          NotificationManager.IMPORTANCE_DEFAULT);
+      mChannel.enableVibration(options.optBoolean(VIBRATE, true));
+      mChannel.setShowBadge(true);
+      notificationManager.createNotificationChannel(mChannel);
     }
   }
 


### PR DESCRIPTION
## Description
Previously we only created our channel if no channels were created, there could be other channels created already so this would leave us without our channel.  We should explicitly check if our channel exists, and not assume we are the only channel.

## Related Issue
https://github.com/phonegap/phonegap-plugin-push/issues/2248

## Motivation and Context
If you are using another plugin that uses notification channels the plug-in will not display the notifications.

## How Has This Been Tested?
Tested in our production application where notifications were failing when we had other plugins using notification testing.  Tested on OnePlus 5 running Android 8.0.
## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
