### PR TITLE
:pengin: Fix Android O+ notification channel custom sound

### DIFF
--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -114,7 +114,7 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
       if (SOUND_RINGTONE.equals(sound)) {
         mChannel.setSound(android.provider.Settings.System.DEFAULT_RINGTONE_URI, audioAttributes);
       } else if (sound != null && !sound.contentEquals(SOUND_DEFAULT)) {
-        Uri soundUri = Uri.parse(ContentResolver.SCHEME_ANDROID_RESOURCE + "://" + packageName + "/raw/" + sound);
+        Uri soundUri = Uri.parse(ContentResolver.SCHEME_ANDROID_RESOURCE + "://" + packageName + "/raw/" + getApplicationContext().getResources().getIdentifier(sound, "raw", packageName));
         mChannel.setSound(soundUri, audioAttributes);
       } else {
         mChannel.setSound(android.provider.Settings.System.DEFAULT_NOTIFICATION_URI, audioAttributes);


### PR DESCRIPTION
Fix no custom sound on Notification channels (Android O+)

## Description
Fixing channel sound uri building by using `getRessource()` method

## Related Issue
#2221 

## Motivation and Context
Allow using custom sounds on Android O and above

## How Has This Been Tested?
Create a new notification channel:
```javascript
PushNotification.createChannel(
        () => {
          console.log('success');
        },
        () => {
          console.log('error');
        },
        {
          id: 'channel',
          description: 'ChannelDescriptionI',
          importance: 3,
          // Defining channel sound
          sound: 'sound'
        }
      );
```
Add in `platforms\android\res\raw` a mp3 file. tested with [https://drive.google.com/open?id=1P9zFSDmQExhVbC4ovL9E0hgT6P6cEYt_]([https://drive.google.com/open?id=1P9zFSDmQExhVbC4ovL9E0hgT6P6cEYt_).  The filename (w/o extension) need to match the `sound` property of the channel.

Without this fix you should ear the default notification sound when a notification is received. With the fix you should ear the custom sound.
You need to reinstall app after patching to recreate channel 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
