### PR TITLE
Docs: Clarify Android push icon color issues

### DIFF
--- a/docs/PAYLOAD.md
+++ b/docs/PAYLOAD.md
@@ -358,9 +358,19 @@ The result will look much like this:
 
 ![2015-07-24 02 52 00](https://cloud.githubusercontent.com/assets/353180/8866899/2df00c3c-3190-11e5-8552-96201fb4424b.png)
 
-This is because Android now uses Material design and the default icon for push will be completely white.
+Note the application icon has gone from being the default, rich, multicolored cordova icon muti-colored, to plain white white.  What going on here?
 
-In order to get a better user experience, you can specify an alternate icon and background color to be shown when receiving a push notification. The code would look like this:
+With Android now using Material design, push notifications are forced to be single-color only - this can be difficult to diagnose, as a lot of icons just show as a white square.
+
+You should design one with these guidelines in mind:
+
+* 96x96 pixels
+* Transparent background
+* White foreground
+
+**Note:** ny color foreground will work - any non-transparent pixels are just rendered white.
+
+To specify an alternate icon and background color to be shown when receiving a push notification, use the following:
 
 ```javascript
 const push = PushNotification.init({


### PR DESCRIPTION
Adds some android icon push guidelines

## Description
Update the docs to make Android icon gotchas more clear, and provide guidance about the format of such.

## Related Issue
https://github.com/phonegap/phonegap-plugin-push/issues/1689#issuecomment-296695264

## Motivation and Context
Ran into the transparent-background-on-Android-push-icons issue, and spent a couple hours debugging it and seeing lots of issues with others having the same issue.  They invariably pointed to the #images section of the payload, but people (myself included) didn't realise what they were talking about.

## How Has This Been Tested?
Just doco

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
