### PR TITLE
Android channel vibration

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -2,9 +2,9 @@
 
 * [.init()](#pushnotificationinitoptions)
 * [.hasPermission()](#pushnotificationhaspermissionsuccesshandler)
-* [.createChannel() - Android only](#pushnotificationcreatechannel)
-* [.deleteChannel() - Android only](#pushnotificationdeletechannel)
-* [.listChannels() - Android only](#pushnotificationlistchannels)
+* [.createChannel() - Android only](#pushnotificationcreatechannelsuccesshandler-failurehandler-channel)
+* [.deleteChannel() - Android only](#pushnotificationdeletechannelsuccesshandler-failurehandler-channelid)
+* [.listChannels() - Android only](#pushnotificationlistchannelssuccesshandler)
 * [push.on()](#pushonevent-callback)
   * [push.on('registration')](#pushonregistration-callback)
   * [push.on('notification')](#pushonnotification-callback)
@@ -203,12 +203,26 @@ PushNotification.createChannel(
   {
     id: 'testchannel1',
     description: 'My first test channel',
-    importance: 3
+    importance: 3,
+    vibration: true
   }
 );
 ```
 
-The above will create a channel for your app. You'll need to provide the `id`, `description` and `importance` properties. The importance property goes from 1 = Lowest, 2 = Low, 3 = Normal, 4 = High and 5 = Highest.
+The above will create a channel for your app. You'll need to provide the `id`, `description` and `importance` properties. 
+
+A default channel with the id "PushPluginChannel" is created automatically. To make changes to the default channel's settings, create a channel with the id "PushPluginChannel" before calling the PushNotification.init function.
+
+### Channel properties
+
+| Property                         | Type      | Description                                                                                                                                                                                                                         |
+| -------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                             | `String`  | The id of the channel. Must be unique per package. The value may be truncated if it is too long.                                                                                                                                    |
+| `description`                    | `String`  | The user visible name of the channel. The recommended maximum length is 40 characters; the value may be truncated if it is too long.                                                                                                |
+| `importance`                     | `Int`     | The importance of the channel. This controls how interruptive notifications posted to this channel are. The importance property goes from 1 = Lowest, 2 = Low, 3 = Normal, 4 = High and 5 = Highest.                                |            
+| `sound`                          | `String`  | The name of the sound file to be played upon receipt of the notification in this channel. Cannot be changed after channel is created.                                                                                               |
+| `vibration`                      | `Boolean` or `Array` | Boolean sets whether notification posted to this channel should vibrate. Array sets custom vibration pattern. Example - vibration: `[2000, 1000, 500, 500]`. Cannot be changed after channel is created.                 |
+| `visibility`                     | `Int`     | Sets whether notifications posted to this channel appear on the lockscreen or not, and if so, whether they appear in a redacted form. 0 = Private, 1 = Public, -1 = Secret.                                                         |
 
 ## PushNotification.deleteChannel(successHandler, failureHandler, channelId)
 


### PR DESCRIPTION
Fixes Android notification channel vibration option.

## Description
Fixes createChannel channel options to allow for vibration settings and updates to related docs.

## Related Issue
Related to https://github.com/phonegap/phonegap-plugin-push/issues/2017

## Motivation and Context
On Android O creating channels is required to customize notifications sounds. When a new channel is created vibration is off by default.

## How Has This Been Tested?
This as been tested on a Pixel running Android 8.1.0 and a Galaxy S7 edge running Android 7.0. Changes were only made in the Android src directory.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
