### PR TITLE
Issue #2266:Update to UNUserNotification API of iOS 10+

### DIFF
--- a/src/ios/AppDelegate+notification.h
+++ b/src/ios/AppDelegate+notification.h
@@ -7,13 +7,14 @@
 //
 
 #import "AppDelegate.h"
+@import UserNotifications;
 
-@interface AppDelegate (notification)
+@interface AppDelegate (notification) <UNUserNotificationCenterDelegate>
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:( void (^)(UIBackgroundFetchResult))completionHandler;
 - (void)pushPluginOnApplicationDidBecomeActive:(UIApplication *)application;
-- (void)application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo completionHandler:(void(^)())completionHandler;
+- (void)checkUserHasRemoteNotificationsEnabledWithCompletionHandler:(nonnull void (^)(BOOL))completionHandler;
 - (id) getCommandInstance:(NSString*)className;
 
 @property (nonatomic, retain) NSDictionary  *launchNotification;

--- a/src/ios/AppDelegate+notification.h
+++ b/src/ios/AppDelegate+notification.h
@@ -9,6 +9,8 @@
 #import "AppDelegate.h"
 @import UserNotifications;
 
+extern NSString *const pushPluginApplicationDidBecomeActiveNotification;
+
 @interface AppDelegate (notification) <UNUserNotificationCenterDelegate>
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;

--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -12,6 +12,8 @@
 
 static char launchNotificationKey;
 static char coldstartKey;
+NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginApplicationDidBecomeActiveNotification";
+
 
 @implementation AppDelegate (notification)
 
@@ -172,6 +174,8 @@ static char coldstartKey;
         self.coldstart = [NSNumber numberWithBool:NO];
         [pushHandler performSelectorOnMainThread:@selector(notificationReceived) withObject:pushHandler waitUntilDone:NO];
     }
+    
+    [[NSNotificationCenter defaultCenter] postNotificationName:pushPluginApplicationDidBecomeActiveNotification object:nil];
 }
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center

--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -53,10 +53,9 @@ static char coldstartKey;
 
 - (AppDelegate *)pushPluginSwizzledInit
 {
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(createNotificationChecker:)
-                                                 name:UIApplicationDidFinishLaunchingNotification
-                                               object:nil];
+    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+    center.delegate = self;
+    
     [[NSNotificationCenter defaultCenter]addObserver:self
                                             selector:@selector(pushPluginOnApplicationDidBecomeActive:)
                                                 name:UIApplicationDidBecomeActiveNotification
@@ -65,25 +64,6 @@ static char coldstartKey;
     // This actually calls the original init method over in AppDelegate. Equivilent to calling super
     // on an overrided method, this is not recursive, although it appears that way. neat huh?
     return [self pushPluginSwizzledInit];
-}
-
-// This code will be called immediately after application:didFinishLaunchingWithOptions:. We need
-// to process notifications in cold-start situations
-- (void)createNotificationChecker:(NSNotification *)notification
-{
-    NSLog(@"createNotificationChecker");
-    if (notification)
-    {
-        NSDictionary *launchOptions = [notification userInfo];
-        if (launchOptions) {
-            NSLog(@"coldstart");
-            self.launchNotification = [launchOptions objectForKey: @"UIApplicationLaunchOptionsRemoteNotificationKey"];
-            self.coldstart = [NSNumber numberWithBool:YES];
-        } else {
-            NSLog(@"not coldstart");
-            self.coldstart = [NSNumber numberWithBool:NO];
-        }
-    }
 }
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
@@ -96,29 +76,12 @@ static char coldstartKey;
     [pushHandler didFailToRegisterForRemoteNotificationsWithError:error];
 }
 
-- (void) application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo {
-    NSLog(@"clicked on the shade");
-    PushPlugin *pushHandler = [self getCommandInstance:@"PushNotification"];
-    pushHandler.notificationMessage = userInfo;
-    pushHandler.isInline = NO;
-    [pushHandler notificationReceived];
-}
-
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
     NSLog(@"didReceiveNotification with fetchCompletionHandler");
 
-    // app is in the foreground so call notification callback
-    if (application.applicationState == UIApplicationStateActive) {
-        NSLog(@"app active");
-        PushPlugin *pushHandler = [self getCommandInstance:@"PushNotification"];
-        pushHandler.notificationMessage = userInfo;
-        pushHandler.isInline = YES;
-        [pushHandler notificationReceived];
-
-        completionHandler(UIBackgroundFetchResultNewData);
-    }
-    // app is in background or in stand by
-    else {
+    // app is in the background or inactive, so only call notification callback if this is a silent push
+    if (application.applicationState != UIApplicationStateActive) {
+        
         NSLog(@"app in-active");
 
         // do some convoluted logic to find out if this should be a silent push.
@@ -161,22 +124,29 @@ static char coldstartKey;
             NSLog(@"just put it in the shade");
             //save it for later
             self.launchNotification = userInfo;
-
-            completionHandler(UIBackgroundFetchResultNewData);
         }
+        
+        completionHandler(UIBackgroundFetchResultNewData);
+    } else {
+        completionHandler(UIBackgroundFetchResultNoData);
     }
 }
 
-- (BOOL)userHasRemoteNotificationsEnabled {
-    UIApplication *application = [UIApplication sharedApplication];
-    if ([[UIApplication sharedApplication] respondsToSelector:@selector(registerUserNotificationSettings:)]) {
-        return application.currentUserNotificationSettings.types != UIUserNotificationTypeNone;
-    } else {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-        return application.enabledRemoteNotificationTypes != UIRemoteNotificationTypeNone;
-#pragma GCC diagnostic pop
-    }
+- (void)checkUserHasRemoteNotificationsEnabledWithCompletionHandler:(nonnull void (^)(BOOL))completionHandler
+{
+    [[UNUserNotificationCenter currentNotificationCenter] getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
+        
+        switch (settings.authorizationStatus)
+        {
+            case UNAuthorizationStatusDenied:
+            case UNAuthorizationStatusNotDetermined:
+                completionHandler(NO);
+                break;
+            case UNAuthorizationStatusAuthorized:
+                completionHandler(YES);
+                break;
+        }
+    }];
 }
 
 - (void)pushPluginOnApplicationDidBecomeActive:(NSNotification *)notification {
@@ -204,46 +174,75 @@ static char coldstartKey;
     }
 }
 
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+       willPresentNotification:(UNNotification *)notification
+         withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler
+{
+    NSLog( @"NotificationCenter Handle push from foreground" );
+    // custom code to handle push while app is in the foreground
+    PushPlugin *pushHandler = [self getCommandInstance:@"PushNotification"];
+    pushHandler.notificationMessage = notification.request.content.userInfo;
+    pushHandler.isInline = YES;
+    [pushHandler notificationReceived];
+    
+    completionHandler(UNNotificationPresentationOptionNone);
+}
 
-- (void)application:(UIApplication *) application handleActionWithIdentifier: (NSString *) identifier
-forRemoteNotification: (NSDictionary *) notification completionHandler: (void (^)()) completionHandler {
-
-    NSLog(@"Push Plugin handleActionWithIdentifier %@", identifier);
-    NSMutableDictionary *userInfo = [notification mutableCopy];
-    [userInfo setObject:identifier forKey:@"actionCallback"];
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+didReceiveNotificationResponse:(UNNotificationResponse *)response
+         withCompletionHandler:(void(^)(void))completionHandler
+{
+    NSLog(@"Push Plugin didReceiveNotificationResponse: actionIdentifier %@, notification: %@", response.actionIdentifier,
+          response.notification.request.content.userInfo);
+    NSMutableDictionary *userInfo = [response.notification.request.content.userInfo mutableCopy];
+    [userInfo setObject:response.actionIdentifier forKey:@"actionCallback"];
     NSLog(@"Push Plugin userInfo %@", userInfo);
-
-    if (application.applicationState == UIApplicationStateActive) {
-        PushPlugin *pushHandler = [self getCommandInstance:@"PushNotification"];
-        pushHandler.notificationMessage = userInfo;
-        pushHandler.isInline = NO;
-        [pushHandler notificationReceived];
-    } else {
-        void (^safeHandler)() = ^(void){
-            dispatch_async(dispatch_get_main_queue(), ^{
-                completionHandler();
-            });
-        };
-
-        PushPlugin *pushHandler = [self getCommandInstance:@"PushNotification"];
-
-        if (pushHandler.handlerObj == nil) {
-            pushHandler.handlerObj = [NSMutableDictionary dictionaryWithCapacity:2];
+    
+    switch ([UIApplication sharedApplication].applicationState) {
+        case UIApplicationStateActive:
+        {
+            PushPlugin *pushHandler = [self getCommandInstance:@"PushNotification"];
+            pushHandler.notificationMessage = userInfo;
+            pushHandler.isInline = NO;
+            [pushHandler notificationReceived];
+            completionHandler();
+            break;
         }
-
-        id notId = [userInfo objectForKey:@"notId"];
-        if (notId != nil) {
-            NSLog(@"Push Plugin notId %@", notId);
-            [pushHandler.handlerObj setObject:safeHandler forKey:notId];
-        } else {
-            NSLog(@"Push Plugin notId handler");
-            [pushHandler.handlerObj setObject:safeHandler forKey:@"handler"];
+        case UIApplicationStateInactive:
+        {
+            NSLog(@"coldstart");
+            self.launchNotification = response.notification.request.content.userInfo;
+            self.coldstart = [NSNumber numberWithBool:YES];
+            break;
         }
-
-        pushHandler.notificationMessage = userInfo;
-        pushHandler.isInline = NO;
-
-        [pushHandler performSelectorOnMainThread:@selector(notificationReceived) withObject:pushHandler waitUntilDone:NO];
+        case UIApplicationStateBackground:
+        {
+            void (^safeHandler)(void) = ^(void){
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    completionHandler();
+                });
+            };
+            
+            PushPlugin *pushHandler = [self getCommandInstance:@"PushNotification"];
+            
+            if (pushHandler.handlerObj == nil) {
+                pushHandler.handlerObj = [NSMutableDictionary dictionaryWithCapacity:2];
+            }
+            
+            id notId = [userInfo objectForKey:@"notId"];
+            if (notId != nil) {
+                NSLog(@"Push Plugin notId %@", notId);
+                [pushHandler.handlerObj setObject:safeHandler forKey:notId];
+            } else {
+                NSLog(@"Push Plugin notId handler");
+                [pushHandler.handlerObj setObject:safeHandler forKey:@"handler"];
+            }
+            
+            pushHandler.notificationMessage = userInfo;
+            pushHandler.isInline = NO;
+            
+            [pushHandler performSelectorOnMainThread:@selector(notificationReceived) withObject:pushHandler waitUntilDone:NO];
+        }
     }
 }
 

--- a/src/ios/PushPlugin.h
+++ b/src/ios/PushPlugin.h
@@ -23,7 +23,8 @@
  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <Foundation/Foundation.h>
+@import Foundation;
+@import UserNotifications;
 #import <Cordova/CDV.h>
 #import <Cordova/CDVPlugin.h>
 #import <PushKit/PushKit.h>

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -1,16 +1,16 @@
 /*
  Copyright 2009-2011 Urban Airship Inc. All rights reserved.
-
+ 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:
-
+ 
  1. Redistributions of source code must retain the above copyright notice, this
  list of conditions and the following disclaimer.
-
+ 
  2. Redistributions in binaryform must reproduce the above copyright notice,
  this list of conditions and the following disclaimer in the documentation
  and/or other materials provided withthe distribution.
-
+ 
  THIS SOFTWARE IS PROVIDED BY THE URBAN AIRSHIP INC``AS IS'' AND ANY EXPRESS OR
  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
@@ -27,6 +27,7 @@
 #define GMP_NO_MODULES true
 
 #import "PushPlugin.h"
+#import "AppDelegate+notification.h"
 @import FirebaseInstanceID;
 @import FirebaseMessaging;
 @import FirebaseAnalytics;
@@ -53,11 +54,11 @@
 -(void)initRegistration;
 {
     NSString * registrationToken = [[FIRInstanceID instanceID] token];
-
+    
     if (registrationToken != nil) {
         NSLog(@"FCM Registration Token: %@", registrationToken);
         [self setFcmRegistrationToken: registrationToken];
-
+        
         id topics = [self fcmTopics];
         if (topics != nil) {
             for (NSString *topic in topics) {
@@ -66,12 +67,12 @@
                 [pubSub subscribeToTopic:topic];
             }
         }
-
+        
         [self registerWithToken:registrationToken];
     } else {
         NSLog(@"FCM token is null");
     }
-
+    
 }
 
 //  FCM refresh token
@@ -111,7 +112,7 @@
 - (void)unregister:(CDVInvokedUrlCommand*)command;
 {
     NSArray* topics = [command argumentAtIndex:0];
-
+    
     if (topics != nil) {
         id pubSub = [FIRMessaging messaging];
         for (NSString *topic in topics) {
@@ -127,7 +128,7 @@
 - (void)subscribe:(CDVInvokedUrlCommand*)command;
 {
     NSString* topic = [command argumentAtIndex:0];
-
+    
     if (topic != nil) {
         NSLog(@"subscribe from topic: %@", topic);
         id pubSub = [FIRMessaging messaging];
@@ -143,7 +144,7 @@
 - (void)unsubscribe:(CDVInvokedUrlCommand*)command;
 {
     NSString* topic = [command argumentAtIndex:0];
-
+    
     if (topic != nil) {
         NSLog(@"unsubscribe from topic: %@", topic);
         id pubSub = [FIRMessaging messaging];
@@ -164,9 +165,9 @@
     if (([voipArg isKindOfClass:[NSString class]] && [voipArg isEqualToString:@"true"]) || [voipArg boolValue]) {
         [self.commandDelegate runInBackground:^ {
             NSLog(@"Push Plugin VoIP set to true");
-
+            
             self.callbackId = command.callbackId;
-
+            
             PKPushRegistry *pushRegistry = [[PKPushRegistry alloc] initWithQueue:dispatch_get_main_queue()];
             pushRegistry.delegate = self;
             pushRegistry.desiredPushTypes = [NSSet setWithObject:PKPushTypeVoIP];
@@ -176,50 +177,48 @@
         [[NSNotificationCenter defaultCenter]
          addObserver:self selector:@selector(onTokenRefresh)
          name:kFIRInstanceIDTokenRefreshNotification object:nil];
-
+        
         [[NSNotificationCenter defaultCenter]
          addObserver:self selector:@selector(sendDataMessageFailure:)
          name:FIRMessagingSendErrorNotification object:nil];
-
+        
         [[NSNotificationCenter defaultCenter]
          addObserver:self selector:@selector(sendDataMessageSuccess:)
          name:FIRMessagingSendSuccessNotification object:nil];
-
+        
         [[NSNotificationCenter defaultCenter]
          addObserver:self selector:@selector(didDeleteMessagesOnServer)
          name:FIRMessagingMessagesDeletedNotification object:nil];
-
+        
         [self.commandDelegate runInBackground:^ {
             NSLog(@"Push Plugin register called");
             self.callbackId = command.callbackId;
-
+            
             NSArray* topics = [iosOptions objectForKey:@"topics"];
             [self setFcmTopics:topics];
-
-            UIUserNotificationType UserNotificationTypes = UIUserNotificationTypeNone;
-
+            
+            UNAuthorizationOptions authorizationOptions = UNAuthorizationOptionNone;
+            
             id badgeArg = [iosOptions objectForKey:@"badge"];
             id soundArg = [iosOptions objectForKey:@"sound"];
             id alertArg = [iosOptions objectForKey:@"alert"];
             id clearBadgeArg = [iosOptions objectForKey:@"clearBadge"];
-
+            
             if (([badgeArg isKindOfClass:[NSString class]] && [badgeArg isEqualToString:@"true"]) || [badgeArg boolValue])
             {
-                UserNotificationTypes |= UIUserNotificationTypeBadge;
+                authorizationOptions |= UNAuthorizationOptionBadge;
             }
-
+            
             if (([soundArg isKindOfClass:[NSString class]] && [soundArg isEqualToString:@"true"]) || [soundArg boolValue])
             {
-                UserNotificationTypes |= UIUserNotificationTypeSound;
+                authorizationOptions |= UNAuthorizationOptionSound;
             }
-
+            
             if (([alertArg isKindOfClass:[NSString class]] && [alertArg isEqualToString:@"true"]) || [alertArg boolValue])
             {
-                UserNotificationTypes |= UIUserNotificationTypeAlert;
+                authorizationOptions |= UNAuthorizationOptionAlert;
             }
-
-            UserNotificationTypes |= UIUserNotificationActivationModeBackground;
-
+            
             if (clearBadgeArg == nil || ([clearBadgeArg isKindOfClass:[NSString class]] && [clearBadgeArg isEqualToString:@"false"]) || ![clearBadgeArg boolValue]) {
                 NSLog(@"PushPlugin.register: setting badge to false");
                 clearBadge = NO;
@@ -229,84 +228,80 @@
                 [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
             }
             NSLog(@"PushPlugin.register: clear badge is set to %d", clearBadge);
-
+            
             isInline = NO;
-
+            
             NSLog(@"PushPlugin.register: better button setup");
             // setup action buttons
-            NSMutableSet *categories = [[NSMutableSet alloc] init];
+            NSMutableSet<UNNotificationCategory *> *categories = [[NSMutableSet alloc] init];
             id categoryOptions = [iosOptions objectForKey:@"categories"];
             if (categoryOptions != nil && [categoryOptions isKindOfClass:[NSDictionary class]]) {
                 for (id key in categoryOptions) {
                     NSLog(@"categories: key %@", key);
                     id category = [categoryOptions objectForKey:key];
-
+                    
                     id yesButton = [category objectForKey:@"yes"];
-                    UIMutableUserNotificationAction *yesAction;
+                    UNNotificationAction *yesAction;
                     if (yesButton != nil && [yesButton  isKindOfClass:[NSDictionary class]]) {
                         yesAction = [self createAction: yesButton];
                     }
                     id noButton = [category objectForKey:@"no"];
-                    UIMutableUserNotificationAction *noAction;
+                    UNNotificationAction *noAction;
                     if (noButton != nil && [noButton  isKindOfClass:[NSDictionary class]]) {
                         noAction = [self createAction: noButton];
                     }
                     id maybeButton = [category objectForKey:@"maybe"];
-                    UIMutableUserNotificationAction *maybeAction;
+                    UNNotificationAction *maybeAction;
                     if (maybeButton != nil && [maybeButton  isKindOfClass:[NSDictionary class]]) {
                         maybeAction = [self createAction: maybeButton];
                     }
-
-                    // First create the category
-                    UIMutableUserNotificationCategory *notificationCategory = [[UIMutableUserNotificationCategory alloc] init];
-
+                    
                     // Identifier to include in your push payload and local notification
-                    notificationCategory.identifier = key;
-
-                    NSMutableArray *categoryArray = [[NSMutableArray alloc] init];
-                    NSMutableArray *minimalCategoryArray = [[NSMutableArray alloc] init];
+                    NSString *identifier = key;
+                    
+                    NSMutableArray<UNNotificationAction *> *actions = [[NSMutableArray alloc] init];
                     if (yesButton != nil) {
-                        [categoryArray addObject:yesAction];
-                        [minimalCategoryArray addObject:yesAction];
+                        [actions addObject:yesAction];
                     }
                     if (noButton != nil) {
-                        [categoryArray addObject:noAction];
-                        [minimalCategoryArray addObject:noAction];
+                        [actions addObject:noAction];
                     }
                     if (maybeButton != nil) {
-                        [categoryArray addObject:maybeAction];
+                        [actions addObject:maybeAction];
                     }
-
-                    // Add the actions to the category and set the action context
-                    [notificationCategory setActions:categoryArray forContext:UIUserNotificationActionContextDefault];
-
-                    // Set the actions to present in a minimal context
-                    [notificationCategory setActions:minimalCategoryArray forContext:UIUserNotificationActionContextMinimal];
-
+                    
+                    UNNotificationCategory *notificationCategory = [UNNotificationCategory categoryWithIdentifier:identifier
+                                                                                                          actions:actions
+                                                                                                intentIdentifiers:@[]
+                                                                                                          options:UNNotificationCategoryOptionNone];
+                    
                     NSLog(@"Adding category %@", key);
                     [categories addObject:notificationCategory];
                 }
-
+                
             }
-
-            if ([[UIApplication sharedApplication]respondsToSelector:@selector(registerUserNotificationSettings:)]) {
-                UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:UserNotificationTypes categories:categories];
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
-                    [[UIApplication sharedApplication] registerForRemoteNotifications];
-                });
-            }
-
+            
+            UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+            __weak UNUserNotificationCenter *weakCenter = center;
+            [center requestAuthorizationWithOptions:authorizationOptions completionHandler:^(BOOL granted, NSError * _Nullable error) {
+                if (granted) {
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        [[UIApplication sharedApplication] registerForRemoteNotifications];
+                        [weakCenter setNotificationCategories:categories];
+                    });
+                }
+            }];
+            
             // Read GoogleService-Info.plist
             NSString *path = [[NSBundle mainBundle] pathForResource:@"GoogleService-Info" ofType:@"plist"];
-
+            
             // Load the file content and read the data into arrays
             NSDictionary *dict = [[NSDictionary alloc] initWithContentsOfFile:path];
             fcmSenderId = [dict objectForKey:@"GCM_SENDER_ID"];
             BOOL isGcmEnabled = [[dict valueForKey:@"IS_GCM_ENABLED"] boolValue];
-
+            
             NSLog(@"FCM Sender ID %@", fcmSenderId);
-
+            
             //  GCM options
             [self setFcmSenderId: fcmSenderId];
             if(isGcmEnabled && [[self fcmSenderId] length] > 0) {
@@ -322,7 +317,7 @@
                 [self setUsesFCM:NO];
             }
             id fcmSandboxArg = [iosOptions objectForKey:@"fcmSandbox"];
-
+            
             [self setFcmSandbox:@NO];
             if ([self usesFCM] &&
                 (([fcmSandboxArg isKindOfClass:[NSString class]] && [fcmSandboxArg isEqualToString:@"true"]) ||
@@ -331,40 +326,33 @@
                 NSLog(@"Using FCM Sandbox");
                 [self setFcmSandbox:@YES];
             }
-
+            
             if (notificationMessage) {            // if there is a pending startup notification
                 dispatch_async(dispatch_get_main_queue(), ^{
                     // delay to allow JS event handlers to be setup
                     [self performSelector:@selector(notificationReceived) withObject:nil afterDelay: 0.5];
                 });
             }
-
+            
         }];
     }
 }
 
-- (UIMutableUserNotificationAction *)createAction:(NSDictionary *)dictionary {
-
-    UIMutableUserNotificationAction *myAction = [[UIMutableUserNotificationAction alloc] init];
-
-    myAction = [[UIMutableUserNotificationAction alloc] init];
-    myAction.identifier = [dictionary objectForKey:@"callback"];
-    myAction.title = [dictionary objectForKey:@"title"];
-    id mode =[dictionary objectForKey:@"foreground"];
-    if (mode == nil || ([mode isKindOfClass:[NSString class]] && [mode isEqualToString:@"false"]) || ![mode boolValue]) {
-        myAction.activationMode = UIUserNotificationActivationModeBackground;
-    } else {
-        myAction.activationMode = UIUserNotificationActivationModeForeground;
+- (UNNotificationAction *)createAction:(NSDictionary *)dictionary {
+    NSString *identifier = [dictionary objectForKey:@"callback"];
+    NSString *title = [dictionary objectForKey:@"title"];
+    UNNotificationActionOptions options = UNNotificationActionOptionNone;
+    
+    id mode = [dictionary objectForKey:@"foreground"];
+    if (mode != nil && (([mode isKindOfClass:[NSString class]] && [mode isEqualToString:@"true"]) || [mode boolValue])) {
+        options |= UNNotificationActionOptionForeground;
     }
     id destructive = [dictionary objectForKey:@"destructive"];
-    if (destructive == nil || ([destructive isKindOfClass:[NSString class]] && [destructive isEqualToString:@"false"]) || ![destructive boolValue]) {
-        myAction.destructive = NO;
-    } else {
-        myAction.destructive = YES;
+    if (destructive != nil && (([destructive isKindOfClass:[NSString class]] && [destructive isEqualToString:@"true"]) || [destructive boolValue])) {
+        options |= UNNotificationActionOptionDestructive;
     }
-    myAction.authenticationRequired = NO;
-
-    return myAction;
+    
+    return [UNNotificationAction actionWithIdentifier:identifier title:title options:options];
 }
 
 - (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
@@ -373,54 +361,59 @@
         return;
     }
     NSLog(@"Push Plugin register success: %@", deviceToken);
-
+    
     NSMutableDictionary *results = [NSMutableDictionary dictionary];
     NSString *token = [[[[deviceToken description] stringByReplacingOccurrencesOfString:@"<"withString:@""]
                         stringByReplacingOccurrencesOfString:@">" withString:@""]
                        stringByReplacingOccurrencesOfString: @" " withString: @""];
     [results setValue:token forKey:@"deviceToken"];
-
+    
 #if !TARGET_IPHONE_SIMULATOR
     // Get Bundle Info for Remote Registration (handy if you have more than one app)
     [results setValue:[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleDisplayName"] forKey:@"appName"];
     [results setValue:[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"] forKey:@"appVersion"];
-
+    
     // Check what Notifications the user has turned on.  We registered for all three, but they may have manually disabled some or all of them.
-
-    NSUInteger rntypes = [[[UIApplication sharedApplication] currentUserNotificationSettings] types];
-
-    // Set the defaults to disabled unless we find otherwise...
-    NSString *pushBadge = @"disabled";
-    NSString *pushAlert = @"disabled";
-    NSString *pushSound = @"disabled";
-
-    // Check what Registered Types are turned on. This is a bit tricky since if two are enabled, and one is off, it will return a number 2... not telling you which
-    // one is actually disabled. So we are literally checking to see if rnTypes matches what is turned on, instead of by number. The "tricky" part is that the
-    // single notification types will only match if they are the ONLY one enabled.  Likewise, when we are checking for a pair of notifications, it will only be
-    // true if those two notifications are on.  This is why the code is written this way
-    if(rntypes & UIUserNotificationTypeBadge){
-        pushBadge = @"enabled";
-    }
-    if(rntypes & UIUserNotificationTypeAlert) {
-        pushAlert = @"enabled";
-    }
-    if(rntypes & UIUserNotificationTypeSound) {
-        pushSound = @"enabled";
-    }
-
-    [results setValue:pushBadge forKey:@"pushBadge"];
-    [results setValue:pushAlert forKey:@"pushAlert"];
-    [results setValue:pushSound forKey:@"pushSound"];
-
-    // Get the users Device Model, Display Name, Token & Version Number
-    UIDevice *dev = [UIDevice currentDevice];
-    [results setValue:dev.name forKey:@"deviceName"];
-    [results setValue:dev.model forKey:@"deviceModel"];
-    [results setValue:dev.systemVersion forKey:@"deviceSystemVersion"];
-
-    if(![self usesFCM]) {
-        [self registerWithToken: token];
-    }
+    
+    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+    __weak PushPlugin *weakSelf = self;
+    [center getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
+        
+        // Set the defaults to disabled unless we find otherwise...
+        NSString *pushBadge = @"disabled";
+        NSString *pushAlert = @"disabled";
+        NSString *pushSound = @"disabled";
+        
+        // Check what Registered Types are turned on. This is a bit tricky since if two are enabled, and one is off, it will return a number 2... not telling you which
+        // one is actually disabled. So we are literally checking to see if rnTypes matches what is turned on, instead of by number. The "tricky" part is that the
+        // single notification types will only match if they are the ONLY one enabled.  Likewise, when we are checking for a pair of notifications, it will only be
+        // true if those two notifications are on.  This is why the code is written this way
+        if(settings.authorizationStatus & UNAuthorizationOptionBadge){
+            pushBadge = @"enabled";
+        }
+        if(settings.authorizationStatus & UNAuthorizationOptionAlert) {
+            pushAlert = @"enabled";
+        }
+        if(settings.authorizationStatus & UNAuthorizationOptionSound) {
+            pushSound = @"enabled";
+        }
+        
+        [results setValue:pushBadge forKey:@"pushBadge"];
+        [results setValue:pushAlert forKey:@"pushAlert"];
+        [results setValue:pushSound forKey:@"pushSound"];
+        
+        // Get the users Device Model, Display Name, Token & Version Number
+        UIDevice *dev = [UIDevice currentDevice];
+        [results setValue:dev.name forKey:@"deviceName"];
+        [results setValue:dev.model forKey:@"deviceModel"];
+        [results setValue:dev.systemVersion forKey:@"deviceSystemVersion"];
+        
+        if(![weakSelf usesFCM]) {
+            [weakSelf registerWithToken: token];
+        }
+    }];
+    
+    
 #endif
 }
 
@@ -436,21 +429,21 @@
 
 - (void)notificationReceived {
     NSLog(@"Notification received");
-
+    
     if (notificationMessage && self.callbackId != nil)
     {
         NSMutableDictionary* message = [NSMutableDictionary dictionaryWithCapacity:4];
         NSMutableDictionary* additionalData = [NSMutableDictionary dictionaryWithCapacity:4];
-
-
+        
+        
         for (id key in notificationMessage) {
             if ([key isEqualToString:@"aps"]) {
                 id aps = [notificationMessage objectForKey:@"aps"];
-
+                
                 for(id key in aps) {
                     NSLog(@"Push Plugin key: %@", key);
                     id value = [aps objectForKey:key];
-
+                    
                     if ([key isEqualToString:@"alert"]) {
                         if ([value isKindOfClass:[NSDictionary class]]) {
                             for (id messageKey in value) {
@@ -483,26 +476,26 @@
                 [additionalData setObject:[notificationMessage objectForKey:key] forKey:key];
             }
         }
-
+        
         if (isInline) {
             [additionalData setObject:[NSNumber numberWithBool:YES] forKey:@"foreground"];
         } else {
             [additionalData setObject:[NSNumber numberWithBool:NO] forKey:@"foreground"];
         }
-
+        
         if (coldstart) {
             [additionalData setObject:[NSNumber numberWithBool:YES] forKey:@"coldstart"];
         } else {
             [additionalData setObject:[NSNumber numberWithBool:NO] forKey:@"coldstart"];
         }
-
+        
         [message setObject:additionalData forKey:@"additionalData"];
-
+        
         // send notification message
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:message];
         [pluginResult setKeepCallbackAsBool:YES];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
-
+        
         self.coldstart = NO;
         self.notificationMessage = nil;
     }
@@ -512,9 +505,9 @@
 {
     NSMutableDictionary* options = [command.arguments objectAtIndex:0];
     int badge = [[options objectForKey:@"badge"] intValue] ?: 0;
-
+    
     [[UIApplication sharedApplication] setApplicationIconBadgeNumber:badge];
-
+    
     NSString* message = [NSString stringWithFormat:@"app badge count set to %d", badge];
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:message];
     [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
@@ -523,7 +516,7 @@
 - (void)getApplicationIconBadgeNumber:(CDVInvokedUrlCommand *)command
 {
     NSInteger badge = [UIApplication sharedApplication].applicationIconBadgeNumber;
-
+    
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsInt:(int)badge];
     [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
 }
@@ -531,7 +524,7 @@
 - (void)clearAllNotifications:(CDVInvokedUrlCommand *)command
 {
     [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
-
+    
     NSString* message = [NSString stringWithFormat:@"cleared all notifications"];
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:message];
     [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
@@ -539,16 +532,15 @@
 
 - (void)hasPermission:(CDVInvokedUrlCommand *)command
 {
-    BOOL enabled = NO;
     id<UIApplicationDelegate> appDelegate = [UIApplication sharedApplication].delegate;
-    if ([appDelegate respondsToSelector:@selector(userHasRemoteNotificationsEnabled)]) {
-        enabled = [appDelegate performSelector:@selector(userHasRemoteNotificationsEnabled)];
+    if ([appDelegate respondsToSelector:@selector(checkUserHasRemoteNotificationsEnabledWithCompletionHandler:)]) {
+        [appDelegate performSelector:@selector(checkUserHasRemoteNotificationsEnabledWithCompletionHandler:) withObject:^(BOOL isEnabled) {
+            NSMutableDictionary* message = [NSMutableDictionary dictionaryWithCapacity:1];
+            [message setObject:[NSNumber numberWithBool:isEnabled] forKey:@"isEnabled"];
+            CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:message];
+            [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
+        }];
     }
-
-    NSMutableDictionary* message = [NSMutableDictionary dictionaryWithCapacity:1];
-    [message setObject:[NSNumber numberWithBool:enabled] forKey:@"isEnabled"];
-    CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:message];
-    [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
 }
 
 -(void)successWithMessage:(NSString *)myCallbackId withMsg:(NSString *)message
@@ -565,9 +557,9 @@
     NSMutableDictionary* message = [NSMutableDictionary dictionaryWithCapacity:2];
     [message setObject:token forKey:@"registrationId"];
     if ([self usesFCM]) {
-      [message setObject:@"FCM" forKey:@"registrationType"];
+        [message setObject:@"FCM" forKey:@"registrationType"];
     } else {
-      [message setObject:@"APNS" forKey:@"registrationType"];
+        [message setObject:@"APNS" forKey:@"registrationType"];
     }
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:message];
     [pluginResult setKeepCallbackAsBool:YES];
@@ -579,17 +571,17 @@
 {
     NSString        *errorMessage = (error) ? [NSString stringWithFormat:@"%@ - %@", message, [error localizedDescription]] : message;
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:errorMessage];
-
+    
     [self.commandDelegate sendPluginResult:commandResult callbackId:myCallbackId];
 }
 
 -(void) finish:(CDVInvokedUrlCommand*)command
 {
     NSLog(@"Push Plugin finish called");
-
+    
     [self.commandDelegate runInBackground:^ {
         NSString* notId = [command.arguments objectAtIndex:0];
-
+        
         dispatch_async(dispatch_get_main_queue(), ^{
             [NSTimer scheduledTimerWithTimeInterval:0.1
                                              target:self
@@ -597,7 +589,7 @@
                                            userInfo:notId
                                             repeats:NO];
         });
-
+        
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
@@ -606,9 +598,9 @@
 -(void)stopBackgroundTask:(NSTimer*)timer
 {
     UIApplication *app = [UIApplication sharedApplication];
-
+    
     NSLog(@"Push Plugin stopBackgroundTask called");
-
+    
     if (handlerObj) {
         NSLog(@"Push Plugin handlerObj");
         completionHandler = [handlerObj[[timer userInfo]] copy];
@@ -627,14 +619,14 @@
         NSLog(@"VoIPPush Plugin register error - No device token:");
         return;
     }
-
+    
     NSLog(@"VoIPPush Plugin register success");
     const unsigned *tokenBytes = [credentials.token bytes];
     NSString *sToken = [NSString stringWithFormat:@"%08x%08x%08x%08x%08x%08x%08x%08x",
                         ntohl(tokenBytes[0]), ntohl(tokenBytes[1]), ntohl(tokenBytes[2]),
                         ntohl(tokenBytes[3]), ntohl(tokenBytes[4]), ntohl(tokenBytes[5]),
                         ntohl(tokenBytes[6]), ntohl(tokenBytes[7])];
-
+    
     [self registerWithToken:sToken];
 }
 


### PR DESCRIPTION
Update to UNUserNotification API of iOS 10+

## Description
In order to avoid loss of functionality from using deprecated APIs, update the following Apple APIs:

- UILocalNotification => UNNotificationRequest
- UIMutableNotificationAction =>UNNotificationAction
- UIMutableUserNotificationCategory => UINotificationCategory
- UIUserNotificationAction => UNNotificationAction
- UIUserNotificationCategory => UNNotificationCategory
- UIUserNotificationSettings => UNNotificationSettings
- application:handleActionWithIdentifier:forRemoteNotification:completionHandler: => userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:
- application:didReceiveRemoteNotification: => userNotificationCenter:willPresentNotification:withCompletionHandler:

## Related Issue
Issue #2266. It is important to note that this does not solve issue 2266. A further problem that needs to be solved is that [(UNUserNotificationCenter *)currentNotificationCenter](https://developer.apple.com/documentation/usernotifications/unusernotificationcenter/1649510-currentnotificationcenter?language=objc) can only have one delegate. Either the delegate object from cordova-plugin-local-notifications or from this plugin will end up being currentNotificationCenter's delegate, but not both, i.e. only one plugin will get the delegate callbacks.

## Motivation and Context
This change is required because:

Eventually the deprecated Apple APIs will no longer work.

## How Has This Been Tested?

- [x] When sending a message while the app is in the foreground, the 'notification' event is received and the notification is not shown in the system tray.
- [x] When sending a message while the app is in the background, the notification is shown in the system tray.
- [x] When sending a message with content-available: 1 while the app is in the background, the 'notification' event is received and the notification is shown in the system tray. The 'notification' event is received again when the application is opened via tapping the notification.
- [x] When sending a message after killing the app, the notification is shown in the system tray. The 'notification' event is received when the application is opened via tapping the notification.

Environment:
Ionic@3.20.0
Cordova ios@4.5.4
iPhone 8 iOS@11.1.2

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.