### PR TITLE
Android notification data pass

### DIFF
--- a/docs/PAYLOAD.md
+++ b/docs/PAYLOAD.md
@@ -258,6 +258,24 @@ My recommended format for your push payload when using this plugin (while it dif
 }
 ```
 
+However, if you want to use the mixed payload, you can make it so the values in your `data` payload is passed to the app when tapping the notification by adding `click_action: com.adobe.phonegap.push.background.MESSAGING_EVENT` to your `notification` payload.
+Your payload would end up looking something like this:
+
+```json
+{
+  "notification": {
+    "title": "Test Notification",
+    "body": "This offer expires at 11:30 or whatever",
+    "notId": 10,
+    "click_action": "com.adobe.phonegap.push.background.MESSAGING_EVENT"
+  },
+  "data": {
+     "surveyID": "ewtawgreg-gragrag-rgarhthgbad"
+  }
+}
+```
+**Important note:** By using the `notification` object in your payload, in all cases, all custom notification features provided by this plugin are unavailable.
+
 When your app is in the foreground any `on('notification')` handlers you have registered will be called. If your app is in the background, then the notification will show up in the system tray. Clicking on the notification in the system tray will start the app, and your `on('notification')` handler will be called with the following data:
 
 ```json

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,8 @@
       <uses-permission android:name="android.permission.VIBRATE"/>
     </config-file>
     <config-file target="AndroidManifest.xml" parent="/manifest/application">
-      <activity android:name="com.adobe.phonegap.push.PushHandlerActivity" android:exported="true" android:permission="${applicationId}.permission.PushHandlerActivity">
+      <activity android:name="com.adobe.phonegap.push.PushHandlerActivity" android:exported="true" android:permission="${applicationId}.permission.PushHandlerActivity"/>
+      <activity android:name="com.adobe.phonegap.push.BackgroundHandlerActivity" android:exported="true" android:permission="${applicationId}.permission.BackgroundHandlerActivity">
         <intent-filter>
           <action android:name="com.adobe.phonegap.push.background.MESSAGING_EVENT"/>
           <category android:name="android.intent.category.DEFAULT" />
@@ -53,6 +54,7 @@
     <source-file src="src/android/com/adobe/phonegap/push/FCMService.java" target-dir="src/com/adobe/phonegap/push/"/>
     <source-file src="src/android/com/adobe/phonegap/push/PushConstants.java" target-dir="src/com/adobe/phonegap/push/"/>
     <source-file src="src/android/com/adobe/phonegap/push/PushHandlerActivity.java" target-dir="src/com/adobe/phonegap/push/"/>
+    <source-file src="src/android/com/adobe/phonegap/push/BackgroundHandlerActivity.java" target-dir="src/com/adobe/phonegap/push/"/>
     <source-file src="src/android/com/adobe/phonegap/push/PushInstanceIDListenerService.java" target-dir="src/com/adobe/phonegap/push/"/>
     <source-file src="src/android/com/adobe/phonegap/push/PushPlugin.java" target-dir="src/com/adobe/phonegap/push/"/>
     <source-file src="src/android/com/adobe/phonegap/push/BackgroundActionButtonHandler.java" target-dir="src/com/adobe/phonegap/push/"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,12 @@
       <uses-permission android:name="android.permission.VIBRATE"/>
     </config-file>
     <config-file target="AndroidManifest.xml" parent="/manifest/application">
-      <activity android:name="com.adobe.phonegap.push.PushHandlerActivity" android:exported="true" android:permission="${applicationId}.permission.PushHandlerActivity"/>
+      <activity android:name="com.adobe.phonegap.push.PushHandlerActivity" android:exported="true" android:permission="${applicationId}.permission.PushHandlerActivity">
+        <intent-filter>
+          <action android:name="com.adobe.phonegap.push.background.MESSAGING_EVENT"/>
+          <category android:name="android.intent.category.DEFAULT" />
+        </intent-filter>
+      </activity>
       <receiver android:name="com.adobe.phonegap.push.BackgroundActionButtonHandler"/>
       <receiver android:name="com.adobe.phonegap.push.PushDismissedHandler"/>
       <service android:name="com.adobe.phonegap.push.FCMService">

--- a/src/android/com/adobe/phonegap/push/BackgroundHandlerActivity.java
+++ b/src/android/com/adobe/phonegap/push/BackgroundHandlerActivity.java
@@ -10,8 +10,8 @@ import android.util.Log;
 import android.support.v4.app.RemoteInput;
 
 
-public class PushHandlerActivity extends Activity implements PushConstants {
-    private static String LOG_TAG = "Push_HandlerActivity";
+public class BackgroundHandlerActivity extends Activity implements PushConstants {
+    private static String LOG_TAG = "Push_BackgroundHandlerActivity";
 
     /*
      * this activity will be started if the user touches a notification that we own.
@@ -32,7 +32,6 @@ public class PushHandlerActivity extends Activity implements PushConstants {
         Log.v(LOG_TAG, "onCreate");
         String callback = getIntent().getExtras().getString("callback");
         Log.d(LOG_TAG, "callback = " + callback);
-        boolean foreground = getIntent().getExtras().getBoolean("foreground", true);
         boolean startOnBackground = getIntent().getExtras().getBoolean(START_IN_BACKGROUND, false);
         boolean dismissed = getIntent().getExtras().getBoolean(DISMISSED, false);
         Log.d(LOG_TAG, "dismissed = " + dismissed);
@@ -45,24 +44,14 @@ public class PushHandlerActivity extends Activity implements PushConstants {
         boolean isPushPluginActive = PushPlugin.isActive();
         boolean inline = processPushBundle(isPushPluginActive, intent);
 
-        if(inline && android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.N && !startOnBackground){
-            foreground = true;
-        }
-
-        Log.d(LOG_TAG, "bringToForeground = " + foreground);
-
         finish();
 
         if(!dismissed) {
-            Log.d(LOG_TAG, "isPushPluginActive = " + isPushPluginActive);
-            if (!isPushPluginActive && foreground && inline) {
-                Log.d(LOG_TAG, "forceMainActivityReload");
+            // Tap the notification, app should start.
+            if (!isPushPluginActive) {
                 forceMainActivityReload(false);
-            } else if(startOnBackground) {
-                Log.d(LOG_TAG, "startOnBackgroundTrue");
-                forceMainActivityReload(true);
             } else {
-                Log.d(LOG_TAG, "don't want main activity");
+                forceMainActivityReload(true);
             }
         }
     }
@@ -78,9 +67,17 @@ public class PushHandlerActivity extends Activity implements PushConstants {
         if (extras != null) {
             Bundle originalExtras = extras.getBundle(PUSH_BUNDLE);
 
+            if (originalExtras == null) {
+                originalExtras = extras;
+                originalExtras.remove(FROM);
+                originalExtras.remove(MESSAGE_ID);
+                originalExtras.remove(COLLAPSE_KEY);
+            }
+
             originalExtras.putBoolean(FOREGROUND, false);
             originalExtras.putBoolean(COLDSTART, !isPushPluginActive);
             originalExtras.putBoolean(DISMISSED, extras.getBoolean(DISMISSED));
+
             originalExtras.putString(ACTION_CALLBACK, extras.getString(CALLBACK));
             originalExtras.remove(NO_CACHE);
 

--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -98,5 +98,5 @@ public interface PushConstants {
   public static final String DELETE_CHANNEL = "deleteChannel";
   public static final String ONGOING = "ongoing";
   public static final String LIST_CHANNELS = "listChannels";
-  public statis final String MESSAGE_ID = "google.message_id"y
+  public statis final String MESSAGE_ID = "google.message_id";
 }

--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -98,5 +98,5 @@ public interface PushConstants {
   public static final String DELETE_CHANNEL = "deleteChannel";
   public static final String ONGOING = "ongoing";
   public static final String LIST_CHANNELS = "listChannels";
-  public statis final String MESSAGE_ID = "google.message_id";
+  public static final String MESSAGE_ID = "google.message_id";
 }

--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -98,4 +98,5 @@ public interface PushConstants {
   public static final String DELETE_CHANNEL = "deleteChannel";
   public static final String ONGOING = "ongoing";
   public static final String LIST_CHANNELS = "listChannels";
+  public statis final String MESSAGE_ID = "google.message_id"y
 }

--- a/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
+++ b/src/android/com/adobe/phonegap/push/PushHandlerActivity.java
@@ -78,6 +78,13 @@ public class PushHandlerActivity extends Activity implements PushConstants {
         if (extras != null) {
             Bundle originalExtras = extras.getBundle(PUSH_BUNDLE);
 
+            if (originalExtras == null) {
+                originalExtras = extras;
+                originalExtras.remove(FROM);
+                originalExtras.remove(MESSAGE_ID);
+                originalExtras.remove(COLLAPSE_KEY);
+            }
+
             originalExtras.putBoolean(FOREGROUND, false);
             originalExtras.putBoolean(COLDSTART, !isPushPluginActive);
             originalExtras.putBoolean(DISMISSED, extras.getBoolean(DISMISSED));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When using the notification key in combination with the data key in your FCM Android payload, it should be possible to get the values in the data payload to your JS code.
## Description
<!--- Describe your changes in detail -->
In plugin.xml, a value is defined which, when present in the notification part of the payload, will trigger the a BackgroundHandlerActivity. This triggering happens when the user taps the notification.

The BackgroundHandlerActivity is more or less a copy of the PushHandlerActivity with the changes that
1) The BackgroundHandlerActivity should only be triggered by tapping the notification when the correct click_action value is given (if this is wrong, tell me, but i have not been able to trigger it otherwise, see tests below)
2) The BackgroundHandlerActivity always triggers the main activity, background or not. This is because otherwise, the main activity would never be focused and the app wouldn't open.

The payload may look something like this

```
{
    "priority" : "high",
    "notification" : {
        "title": "Title",
        "body": "Body",
        "sound": "default",
        "click_action": "com.adobe.phonegap.push.background.MESSAGING_EVENT"
    },
    "data" : {
      "more": "data goes here"
    },
    "to" : "id"
}
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2364 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When using both the notification and the data keys in a push payload on android, it is impossible to get the information in the data payload.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Code was tested with version 2.1.2 of this plugin due to cordova-android 7.1.0 requirement in latest version which I can not meet at this time.
App was built from Ubuntu 17.10.
Tests were run on Android 6.0.1 OnePlus One
Notifications were sent with Postman.

Sent notifications with and without the new key, with and without a 'notification' object in the payload, in the foreground, background, and closed.

Using data object only, no notification object
- Default behaviour, the click_action is handled by the OS and will only work in the notification payload so this is just does what the existing plugin can do

**Using a combination of notification and data objects in the payload**
In all cases, the notification is handled by the OS and therefore there isn't any of the custom notification building that this plugin does. Note that the click_action key in the data object is the same as not having it at all.

_With the key_
Background - Tapping the notification passes the data to the JS and the main activity gets focused so the app opens.
Foreground - Default behaviour, data gets passed to js, no notification is created.
Closed - Tapping the notification opens the app and passes the data to the js

_Without the key_
Tapping the notification opens the app but no data is passed to the JS

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (at least I think it does)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.