### PR TITLE
Remotely clear all notifications

### DIFF
--- a/docs/PAYLOAD.md
+++ b/docs/PAYLOAD.md
@@ -1246,6 +1246,28 @@ fcm.send(message, (err, response) => {
 
 Do not confuse this with the GCM option of setting the [delivery priority of the message](https://developers.google.com/cloud-messaging/concept-options#setting-the-priority-of-a-message). Which is used by GCM to tell the device whether or not it should wake up to deal with the message.
 
+## Time sensitive notifications
+
+If you are sending notifications which are only valid for a short period of time, it is possible to clear them remotely with another notification.
+Sending a notification which contains `"clearAllNotifications": "true"` in the `data` payload, will clear all previous notifications.
+
+The notification can be a stealth notification (with no `title` or `body`), or it can be a normal notification with full functionality.
+
+For the first case, no visible effects will be created, the notifications will simply disappear.
+For the second case, the existing notifications will disappear, and a new one will be created.
+
+Example:
+```javascript
+{
+    "priority" : "high",
+    "content_available" : true,
+    "data" : {
+      "clearAllNotifications" : "true"
+    },
+    "to" : "id"
+}
+```
+
 ## Picture Messages
 
 Perhaps you want to include a large picture in the notification that you are sending to your users. Luckily you can do that too by sending the following JSON from GCM.
@@ -2003,6 +2025,34 @@ but in order for the same `notification` event you would need to send your push 
 ```
 
 The `title` and `body` need to be in the `notification` part of the payload in order for the OS to pick them up correctly. Everything else should be in the `data` part of the payload.
+
+## Time sensitive notifications
+
+If you are sending notifications which are only valid for a short period of time, it is possible to clear them remotely with another notification.
+Sending a notification which contains `"clearAllNotifications": "true"` in the `data` payload, will clear all previous notifications.
+
+The notification can be a stealth notification (with no `title` or `body` or even 'notification' payload), or it can be a normal notification with full functionality.
+
+For the first case, no visible effects will be created, the notifications will simply disappear.
+For the second case, the existing notifications will disappear, and a new one will be created.
+
+Example:
+```javascript
+{
+    "priority" : "high",
+    "content_available" : true,
+    "notification": {
+         "title": "some title or another",
+         "body": "some body or another",
+    },
+    "data" : {
+         "clearAllNotifications" : "true"
+    },
+    "to" : "id"
+}
+```
+
+**Important** On iOS, this functionality will not work if the app is force-closed.
 
 ## GCM Messages Not Arriving
 

--- a/src/android/com/adobe/phonegap/push/FCMService.java
+++ b/src/android/com/adobe/phonegap/push/FCMService.java
@@ -319,6 +319,7 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
     String title = extras.getString(TITLE);
     String contentAvailable = extras.getString(CONTENT_AVAILABLE);
     String forceStart = extras.getString(FORCE_START);
+    String clearNotifications = extras.getString(CLEAR_ALL_NOTIFICATIONS);
     int badgeCount = extractBadgeCount(extras);
     if (badgeCount >= 0) {
       Log.d(LOG_TAG, "count =[" + badgeCount + "]");
@@ -329,6 +330,12 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
     Log.d(LOG_TAG, "title =[" + title + "]");
     Log.d(LOG_TAG, "contentAvailable =[" + contentAvailable + "]");
     Log.d(LOG_TAG, "forceStart =[" + forceStart + "]");
+    Log.d(LOG_TAG, "clearNotifications =[" + clearNotifications + "]");
+
+    if ("true".equals(clearNotifications)) {
+      NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+      notificationManager.cancelAll();
+    }
 
     if ((message != null && message.length() != 0) || (title != null && title.length() != 0)) {
 

--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -107,6 +107,15 @@ static char coldstartKey;
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
     NSLog(@"didReceiveNotification with fetchCompletionHandler");
 
+    id clearAllNotifications = [userInfo objectForKey:@"clearAllNotifications"];
+    if ([clearAllNotifications isKindOfClass:[NSString class]] && [clearAllNotifications isEqualToString:@"true"]) {
+        NSLog(@"PushPlugin clearing notifications");
+
+        [[UIApplication sharedApplication] setApplicationIconBadgeNumber:1];
+        [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
+        [[UIApplication sharedApplication] cancelAllLocalNotifications];
+    }
+
     // app is in the foreground so call notification callback
     if (application.applicationState == UIApplicationStateActive) {
         NSLog(@"app active");

--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -108,7 +108,7 @@ static char coldstartKey;
     NSLog(@"didReceiveNotification with fetchCompletionHandler");
 
     id clearAllNotifications = [userInfo objectForKey:@"clearAllNotifications"];
-    if ([clearAllNotifications isKindOfClass:[NSString class]] && [clearAllNotifications isEqualToString:@"true"]) {
+    if (([clearAllNotifications isKindOfClass:[NSString class]] && [clearAllNotifications isEqualToString:@"true"]) || [clearAllNotifications boolValue]) {
         NSLog(@"PushPlugin clearing notifications");
 
         [[UIApplication sharedApplication] setApplicationIconBadgeNumber:1];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added handling for a `"clearAllNotifications": "true"` key-value pair on iOS and Android which clears the notifications.

## Description
<!--- Describe your changes in detail -->
Simply added code which gets the value from the payload, and if it's "true", it executes code which removes notifications from the notification area.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2371
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It's a straight-forward way to clear time-sensitive notifications an app may have. Simply send the payload, and it's done.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Android 6.0.1 and iOS 11.3.1
Notifications sent via Postman

Sent notifications to both platforms, both in background and force-closed. Then, sent the payload which clears the notififications.

**Android**
Background: Notifications all disappear.
Force-closed: Notifications all disappear.

**iOS**
Background: Notifications all disappear
Force-closed: Nothing happens. Doesn't seem to be able to run the code. Would love some help with this if you want.

**iOS note** : Why does the iOS code first increment the iconApplicationBadgeNumber and then clear it before removing the notifications?
Simply put, it just didn't work otherwise. If you know better, let me know.

Notification used to clear the pre-existing notifications:
```
{
    "priority" : "high",
    "content_available" : true,
    "data" : {
      "notId": 0,
      "clearAllNotifications" : "true"
    },
    "to" : "id"
}
```

In the case that you send a notification with a body and a title, and it also contains this payload (see what I mean below), first, the old notifications will be cleared, and then the new notification will be added. This will result in one remaining notification in the notification drawer.

Android:
```
{
    "priority" : "high",
    "content_available" : true,
    "data" : {
      "title": "some title or another",
      "body": "some body or another",
      "notId": 0,
      "clearAllNotifications" : "true"
    },
    "to" : "id"
}
```

iOS:
```
{
    "priority" : "high",
    "content_available" : true,
    "notification": {
         "title": "some title or another",
         "body": "some body or another",  
    },
    "data" : {
      "notId": 0,
      "clearAllNotifications" : "true"
    },
    "to" : "id"
}
```

## Screenshots (if appropriate):
N/A
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
