### PR TITLE
the completionHandler moved in the else statement

### DIFF
--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -57,7 +57,7 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
 {
     UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
     center.delegate = self;
-    
+
     [[NSNotificationCenter defaultCenter]addObserver:self
                                             selector:@selector(pushPluginOnApplicationDidBecomeActive:)
                                                 name:UIApplicationDidBecomeActiveNotification
@@ -83,7 +83,7 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
 
     // app is in the background or inactive, so only call notification callback if this is a silent push
     if (application.applicationState != UIApplicationStateActive) {
-        
+
         NSLog(@"app in-active");
 
         // do some convoluted logic to find out if this should be a silent push.
@@ -126,9 +126,9 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
             NSLog(@"just put it in the shade");
             //save it for later
             self.launchNotification = userInfo;
+            completionHandler(UIBackgroundFetchResultNewData);
         }
-        
-        completionHandler(UIBackgroundFetchResultNewData);
+
     } else {
         completionHandler(UIBackgroundFetchResultNoData);
     }
@@ -137,7 +137,7 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
 - (void)checkUserHasRemoteNotificationsEnabledWithCompletionHandler:(nonnull void (^)(BOOL))completionHandler
 {
     [[UNUserNotificationCenter currentNotificationCenter] getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
-        
+
         switch (settings.authorizationStatus)
         {
             case UNAuthorizationStatusDenied:
@@ -174,7 +174,7 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
         self.coldstart = [NSNumber numberWithBool:NO];
         [pushHandler performSelectorOnMainThread:@selector(notificationReceived) withObject:pushHandler waitUntilDone:NO];
     }
-    
+
     [[NSNotificationCenter defaultCenter] postNotificationName:pushPluginApplicationDidBecomeActiveNotification object:nil];
 }
 
@@ -188,7 +188,7 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
     pushHandler.notificationMessage = notification.request.content.userInfo;
     pushHandler.isInline = YES;
     [pushHandler notificationReceived];
-    
+
     completionHandler(UNNotificationPresentationOptionNone);
 }
 
@@ -201,7 +201,7 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
     NSMutableDictionary *userInfo = [response.notification.request.content.userInfo mutableCopy];
     [userInfo setObject:response.actionIdentifier forKey:@"actionCallback"];
     NSLog(@"Push Plugin userInfo %@", userInfo);
-    
+
     switch ([UIApplication sharedApplication].applicationState) {
         case UIApplicationStateActive:
         {
@@ -226,13 +226,13 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
                     completionHandler();
                 });
             };
-            
+
             PushPlugin *pushHandler = [self getCommandInstance:@"PushNotification"];
-            
+
             if (pushHandler.handlerObj == nil) {
                 pushHandler.handlerObj = [NSMutableDictionary dictionaryWithCapacity:2];
             }
-            
+
             id notId = [userInfo objectForKey:@"notId"];
             if (notId != nil) {
                 NSLog(@"Push Plugin notId %@", notId);
@@ -241,10 +241,10 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
                 NSLog(@"Push Plugin notId handler");
                 [pushHandler.handlerObj setObject:safeHandler forKey:@"handler"];
             }
-            
+
             pushHandler.notificationMessage = userInfo;
             pushHandler.isInline = NO;
-            
+
             [pushHandler performSelectorOnMainThread:@selector(notificationReceived) withObject:pushHandler waitUntilDone:NO];
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR is very simple.
Calling completionHandler after finishing javascript notification handler for the iOS silent push.

## Description
<!--- Describe your changes in detail -->

For the iOS silent push, the working flow should be following.
(Supposing the device state is background and the push notification has the property `content-available=1`)

Obj-C => Receive PushNotification  
Obj-C => define safeHandler in which completionHandler is embedded
Obj-C => call JavaScript handler               
 (start javascript handler)
JavaScript => do something necessary in app 
JavaScript => call Obj-C by push.finish     
(finish javascript handler)
Obj-C => do completionHandler in safeHandler

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If the completionHandler is called before starting javascript handler,
calling other Obj-C in javascript handler is paused.
Calling other Obj-c resumes after application state becomes active.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Here is sample code,
```
  push.on('notification', (data) => {
    var additionalData = data["additionalData"];
    if (additionalData["foreground"]==false && additionalData["coldstart"]==false) {
      id = additionalData["notId"] || "handler";

      var pushFinish = function() {
        push.finish( function() {
          console.log("finish success");
        }, function() {
          console.log("finish fail");
        }, id);
      }
      push.setApplicationIconBadgeNumber( function() { console.log("badge success"); pushFinish(); },
                                          function() { console.log("badge failure"); pushFinish(); }, 99);
    } else {
      alert(data);
    }
  });
```
This handler sets badge number to 99 when background app receives silent push. 
Before applying this PR, the badge number becomes 99 after launching app.
After applying this PR, the badge number becomes 99 as soon as receiving push notification.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
