### PR TITLE
v1.x Fixes NotificationChannel error on Android 8.0

### DIFF
--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -349,11 +349,6 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
 
             NotificationChannel mChannel = new NotificationChannel(appName, name, importance);
             mChannel.setDescription(Description);
-            mChannel.enableLights(true);
-            mChannel.setLightColor(Color.RED);
-            mChannel.enableVibration(true);
-            mChannel.setVibrationPattern(new long[]{100, 200, 300, 400, 500, 400, 300, 200, 400});
-            mChannel.setShowBadge(false);
             mNotificationManager.createNotificationChannel(mChannel);
         }
         Intent notificationIntent = new Intent(this, PushHandlerActivity.class);

--- a/src/android/com/adobe/phonegap/push/GCMIntentService.java
+++ b/src/android/com/adobe/phonegap/push/GCMIntentService.java
@@ -2,6 +2,7 @@ package com.adobe.phonegap.push;
 
 import android.annotation.SuppressLint;
 import android.app.Notification;
+import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.ContentResolver;
@@ -340,6 +341,21 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
         Resources resources = context.getResources();
 
         int notId = parseInt(NOT_ID, extras);
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+            CharSequence name = appName;
+            String Description = "Push notification channel";
+            int importance = NotificationManager.IMPORTANCE_HIGH;
+            Log.d(LOG_TAG, "creating channel=" + appName);
+
+            NotificationChannel mChannel = new NotificationChannel(appName, name, importance);
+            mChannel.setDescription(Description);
+            mChannel.enableLights(true);
+            mChannel.setLightColor(Color.RED);
+            mChannel.enableVibration(true);
+            mChannel.setVibrationPattern(new long[]{100, 200, 300, 400, 500, 400, 300, 200, 400});
+            mChannel.setShowBadge(false);
+            mNotificationManager.createNotificationChannel(mChannel);
+        }
         Intent notificationIntent = new Intent(this, PushHandlerActivity.class);
         notificationIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
         notificationIntent.putExtra(PUSH_BUNDLE, extras);
@@ -358,7 +374,7 @@ public class GCMIntentService extends GcmListenerService implements PushConstant
         PendingIntent deleteIntent = PendingIntent.getBroadcast(this, requestCode, dismissedNotificationIntent, PendingIntent.FLAG_CANCEL_CURRENT);
 
         NotificationCompat.Builder mBuilder =
-                new NotificationCompat.Builder(context)
+                new NotificationCompat.Builder(context, appName)
                         .setWhen(System.currentTimeMillis())
                         .setContentTitle(fromHtml(extras.getString(TITLE)))
                         .setTicker(fromHtml(extras.getString(TITLE)))


### PR DESCRIPTION
## Description
Added a NotificationChannel which is required for GCM push notifications to work on Android 8.0

## Related Issue
#2421 

## Motivation and Context
When sending a push notification to a device running Android 8.0, the following message was displayed: Developer warning for package "my-package". Failed to post notification on channel "null". See log for details.'

## How Has This Been Tested?
I have tested this on Android 8.0 and 7.1 emulators and now correctly receive push notifications

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
