### PR TITLE
:bug: :apple: Issue #1141: Clear application badge on first launch

### DIFF
--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -154,6 +154,14 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
 - (void)pushPluginOnApplicationDidBecomeActive:(NSNotification *)notification {
 
     NSLog(@"active");
+    
+    NSString *firstLaunchKey = @"firstLaunchKey";
+    NSUserDefaults *defaults = [[NSUserDefaults alloc] initWithSuiteName:@"phonegap-plugin-push"];
+    if (![defaults boolForKey:firstLaunchKey]) {
+        NSLog(@"application first launch: remove badge icon number");
+        [defaults setBool:YES forKey:firstLaunchKey];
+        [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
+    }
 
     UIApplication *application = notification.object;
 


### PR DESCRIPTION
## Description
If the app has a badge icon and is uninstalled and reinstalled within a short period of time, the app badge icon will persist on reinstall. It should be cleared on launch.

## Related Issue
Issue #1141. I have been unable to reproduce the issue of the badge icon always being set to 1. When passing
`{ ios:  {
    alert: 'true',
    badge: 'false',
    sound: 'false'
    } 
  }` to the `init` function, the badge icon never shows up. I was, however, able to reproduce the issue where the badge icon persists after uninstalling and reinstalling the app.

## Motivation and Context
Users will expect after uninstalling and reinstalling the app that the app badge icon will be cleared. Developers may need to delay calling the `init` function for some time after the initial app launch, so calling `push.setApplicationIconBadgeNumber()` may not be an option.

## How Has This Been Tested?
- [x] When passing
`{ ios:  {
    alert: 'true',
    badge: 'false',
    sound: 'false'
    } 
  }` to the `init` function, the badge icon never shows up.
- [x] When the app has a badge icon and is uninstalled and reinstalled, it is cleared when the application is first launched.
- [x] When the app has a badge icon and is resumed/launched _after_ the first launch, the badge icon is _not_ cleared.

Environment:
Ionic@3.20.0
Cordova ios@4.5.4
iPhone 8 iOS@11.1.2

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.