### PR TITLE
Support to use this plugin with a custom broadcastReceiver

### DIFF
--- a/src/android/com/adobe/phonegap/push/FCMService.java
+++ b/src/android/com/adobe/phonegap/push/FCMService.java
@@ -70,7 +70,10 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
 
   @Override
   public void onMessageReceived(RemoteMessage message) {
+    handleMessage(getApplicationContext(), message);
+  }
 
+  public void handleMessage(Context context, RemoteMessage message) {
     String from = message.getFrom();
     Log.d(LOG_TAG, "onMessage - from: " + from);
 
@@ -87,20 +90,18 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
       extras.putString(entry.getKey(), entry.getValue());
     }
 
-    if (extras != null && isAvailableSender(from)) {
-      Context applicationContext = getApplicationContext();
-
-      SharedPreferences prefs = applicationContext.getSharedPreferences(PushPlugin.COM_ADOBE_PHONEGAP_PUSH,
+    if (extras != null && isAvailableSender(context, from)) {
+      SharedPreferences prefs = context.getSharedPreferences(PushPlugin.COM_ADOBE_PHONEGAP_PUSH,
           Context.MODE_PRIVATE);
       boolean forceShow = prefs.getBoolean(FORCE_SHOW, false);
       boolean clearBadge = prefs.getBoolean(CLEAR_BADGE, false);
       String messageKey = prefs.getString(MESSAGE_KEY, MESSAGE);
       String titleKey = prefs.getString(TITLE_KEY, TITLE);
 
-      extras = normalizeExtras(applicationContext, extras, messageKey, titleKey);
+      extras = normalizeExtras(context, extras, messageKey, titleKey);
 
       if (clearBadge) {
-        PushPlugin.setApplicationIconBadgeNumber(getApplicationContext(), 0);
+        PushPlugin.setApplicationIconBadgeNumber(context, 0);
       }
 
       // if we are in the foreground and forceShow is `false` only send data
@@ -116,7 +117,7 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
         extras.putBoolean(FOREGROUND, true);
         extras.putBoolean(COLDSTART, false);
 
-        showNotificationIfPossible(applicationContext, extras);
+        showNotificationIfPossible(context, extras);
       }
       // if we are not in the foreground always send notification if the data has at least a message or title
       else {
@@ -124,7 +125,7 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
         extras.putBoolean(FOREGROUND, false);
         extras.putBoolean(COLDSTART, PushPlugin.isActive());
 
-        showNotificationIfPossible(applicationContext, extras);
+        showNotificationIfPossible(context, extras);
       }
     }
   }
@@ -934,8 +935,8 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
       return null;
   }
 
-  private boolean isAvailableSender(String from) {
-    SharedPreferences sharedPref = getApplicationContext().getSharedPreferences(PushPlugin.COM_ADOBE_PHONEGAP_PUSH,
+  private boolean isAvailableSender(Context context, String from) {
+    SharedPreferences sharedPref = context.getSharedPreferences(PushPlugin.COM_ADOBE_PHONEGAP_PUSH,
         Context.MODE_PRIVATE);
     String savedSenderID = sharedPref.getString(SENDER_ID, "");
 


### PR DESCRIPTION
I've been working with this plugin for a little while now and I realised it's currently not that easy to use this plugin in combination with other broadcast receivers. 

## Description
Basically what I did is changed the onMessageReceive method to be forwarded to another function which I could also call from another file (with context). So instead of handling the notification in the onMessageReceived I created another function (handleMessage) which does exactly the same as before just now with a context variable. 

## Related Issue
Okay so right now there is no issue discussed about this, I was just doing this for my own project but felt like It could help alot more people struggling with multiple broadcasting services.

## Motivation and Context
I know phonegap-plugin-push works with almost all push notification senders that support cordova
 right now but there are still alot of custom options available to us programmers. Just this was the case in a current project of mine which is using CleverTap and is actually relying on CleverTap notifications alot. This forced me to write a custom BroadcastReceiver to split up the messages that I receive.

Doing this and invoking FCMService.onMessageReceived() caused alot of NullPointerExceptions because of Context. That's why I split it up, now you could do the exact same thing without noticing but also call the handleMessage method to use it in a custom BroadcastReceiver.

MyCustomBroadcastReceiver
```
public class CustomBroadcastReceiver extends FirebaseMessagingService {

  private static final String LOG_TAG = "CustomBroadcastReceiver";

  @Override
  public void onMessageReceived(RemoteMessage message) {
    Bundle extras = new Bundle();

    for (Map.Entry<String, String> entry : message.getData().entrySet()) {
      extras.putString(entry.getKey(), entry.getValue());
    }

    NotificationInfo info = CleverTapAPI.getNotificationInfo(extras);

    if (info.fromCleverTap) {
      Log.d(LOG_TAG, "Received notification from CleverTap: " + extras.toString());
      CleverTapAPI.createNotification(getApplicationContext(), extras);
    } else {
      Log.d(LOG_TAG, "Received notification from API" + extras.toString());

      FCMService fcm = new FCMService();
      fcm.handleMessage(getApplicationContext(), message);
    }
  }
}

Even with this change you will still need a forked version of this plugin for it function with the custom receiver. But I would say It does make the job alot easier for people getting into developing their own receiver. Basically all they would have to do is disable the phonegap-plugin-push receiver and add their own. When the plugin updates just pull from origin and you should be good after this change. 

Right now if I would pull origin things get messy very quickly and rewriting will be necessary at the forked side of thing.
```

## How Has This Been Tested?
I've tested this all on Cordova@7.0.1 and Cordova@7.1.0 with cordova-android 6.3.0.
It shouldn't affect other versions but I did not test thorough with other versions. 

I've used 3 devices:
- OnePlus 5 - Android 7.0
- OnePlus 5T - Android 8.1
- Samsung Galaxy S6 - Android 7.0

All working as expected. 

Unfortunately I couldn't test on lower Android versions since I do not own any.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

It's not really a new feature, nor a bug that is fixed. Just some easier code to implement when using a custom broadcast-reciever and a forked version of this plugin.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
