### PR TITLE
Issue #2191: Implement the ability to clear one notification on iOS

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -17,7 +17,7 @@
 - [push.getApplicationIconBadgeNumber() - iOS & Android only](#pushgetapplicationiconbadgenumbersuccesshandler-errorhandler---ios--android-only)
 - [push.finish() - iOS only](#pushfinishsuccesshandler-errorhandler-id---ios-only)
 - [push.clearAllNotifications() - iOS & Android only](#pushclearallnotificationssuccesshandler-errorhandler---ios--android-only)
-- [push.clearNotification() - Android only](#pushclearnotificationid-successhandler-errorhandler---android-only)
+- [push.clearNotification() - iOS & Android only](#pushclearnotificationid-successhandler-errorhandler---ios--android-only)
 
 ## PushNotification.init(options)
 
@@ -592,7 +592,7 @@ push.clearAllNotifications(
 );
 ```
 
-## push.clearNotification(id, successHandler, errorHandler) - Android only
+## push.clearNotification(id, successHandler, errorHandler) - iOS & Android only
 
 Tells the OS to clear the notification that corresponds to the id argument, from the Notification Center
 

--- a/docs/PAYLOAD.md
+++ b/docs/PAYLOAD.md
@@ -159,6 +159,7 @@ The JSON message can contain the following fields, see [Apple developer docs](ht
     "thread-id": "id", // Provide this key with a string value that represents the app-specific identifier for grouping notifications
     "sound": "default"  // play default sound, or custom sound, see [iOS Sound](#sound-1) section
   },
+  "notId": 1,
   "custom_key1": "value1",
   "custom_key2": "value2"
 }
@@ -171,7 +172,7 @@ This is the JSON-encoded format you can send via AWS-SNS's web UI:
 ```json
 {
   "APNS_SANDBOX":
-    "{\"aps\":{\"alert\":{\"title\":\"A short string describing the purpose of the notification\",\"body\":\"The text of the alert message\",\"launch-image\":\"The filename of an image file in the app bundle, with or without the filename extension. The image is used as the launch image when users tap the action button or move the action slider\"},\"badge\":5,\"content-available\":\"0\",\"category\":\"identifier\",\"thread-id\":\"id\",\"sound\":\"default\"},\"custom_key1\":\"value1\",\"custom_key2\":\"value2\"}"
+    "{\"aps\":{\"alert\":{\"title\":\"A short string describing the purpose of the notification\",\"body\":\"The text of the alert message\",\"launch-image\":\"The filename of an image file in the app bundle, with or without the filename extension. The image is used as the launch image when users tap the action button or move the action slider\"},\"badge\":5,\"content-available\":\"0\",\"category\":\"identifier\",\"thread-id\":\"id\",\"sound\":\"default\"},\"notId\":1,\"custom_key1\":\"value1\",\"custom_key2\":\"value2\"}"
 }
 ```
 
@@ -201,6 +202,7 @@ Note that the properties are "normalized" accross platforms, so this is passed t
     "coldstart": false,
     "foreground": false,
     "content-available": "0",
+    "notId": 1,
     "custom_key1": "value1",
     "custom_key2": "value2",
     "launch-image": "The filename of an image file in the app bundle, with or without the filename extension. The image is used as the launch image when users tap the action button or move the action slider",

--- a/src/ios/PushPlugin.h
+++ b/src/ios/PushPlugin.h
@@ -59,6 +59,7 @@
 - (void)unregister:(CDVInvokedUrlCommand*)command;
 - (void)subscribe:(CDVInvokedUrlCommand*)command;
 - (void)unsubscribe:(CDVInvokedUrlCommand*)command;
+- (void)clearNotification:(CDVInvokedUrlCommand*)command;
 
 - (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 - (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -501,6 +501,28 @@
     }
 }
 
+- (void)clearNotification:(CDVInvokedUrlCommand *)command
+{
+    NSNumber *notId = [command.arguments objectAtIndex:0];
+    [[UNUserNotificationCenter currentNotificationCenter] getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> * _Nonnull notifications) {
+        /*
+         * If the server generates a unique "notId" for every push notification, there should only be one match in these arrays, but if not, it will delete
+         * all notifications with the same value for "notId"
+         */
+        NSPredicate *matchingNotificationPredicate = [NSPredicate predicateWithFormat:@"request.content.userInfo.notId == %@", notId];
+        NSArray<UNNotification *> *matchingNotifications = [notifications filteredArrayUsingPredicate:matchingNotificationPredicate];
+        NSMutableArray<NSString *> *matchingNotificationIdentifiers = [NSMutableArray array];
+        for (UNNotification *notification in matchingNotifications) {
+            [matchingNotificationIdentifiers addObject:notification.request.identifier];
+        }
+        [[UNUserNotificationCenter currentNotificationCenter] removeDeliveredNotificationsWithIdentifiers:matchingNotificationIdentifiers];
+        
+        NSString *message = [NSString stringWithFormat:@"Cleared notification with ID: %@", notId];
+        CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:message];
+        [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
+    }];
+}
+
 - (void)setApplicationIconBadgeNumber:(CDVInvokedUrlCommand *)command
 {
     NSMutableDictionary* options = [command.arguments objectAtIndex:0];


### PR DESCRIPTION
## Description
1. Implement the ability to clear one notification by the "notId" key in the push payload for iOS.
2. Update documentation per item 1.

## Related Issue
Issue #2191

## Motivation and Context
It is desired to have the same feature on both iOS and Android.

## How Has This Been Tested?
iPhone 8 iOS@11.1.2
Cordova@8.0.0
Cordova ios@4.5.4
Ionic CLI@3.20.0
Xcode@9.3
 
1. Send a "content-available" notification while the app is in the background with a "notId" entry in the push payload.
2. Observe that the notification is in the Notification Center.
3. Record the "notId" value in the push payload.
4. Open the app and call the plugin's method to delete the notification by the recorded "notId" value.
5. Observe that the notification is no longer in the Notification Center, and that the success callback is executed.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
