### PR TITLE
Fixes #2502: iOS incompatibility with other Firebase plugins

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -82,7 +82,7 @@
     <source-file src="src/ios/PushPlugin.m"/>
     <header-file src="src/ios/AppDelegate+notification.h"/>
     <header-file src="src/ios/PushPlugin.h"/>
-    <framework src="FirebaseMessaging" type="podspec" spec="~> 2.0.0"/>
+    <framework src="Firebase/Messaging" type="podspec" spec="~> 5.0"/>
     <framework src="PushKit.framework"/>
   </platform>
   <platform name="windows">

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -28,9 +28,7 @@
 
 #import "PushPlugin.h"
 #import "AppDelegate+notification.h"
-@import FirebaseInstanceID;
-@import FirebaseMessaging;
-@import FirebaseAnalytics;
+@import Firebase;
 
 @implementation PushPlugin : CDVPlugin
 


### PR DESCRIPTION
## Description
Changed config.xml and PushPlugin.m

## Related Issue
#2502 

## Motivation and Context
Solves plugin installation error when other plugins present use certain Firebase features already. Installation is now absolutely flawless.

## How Has This Been Tested?
Tested on iOS 11.4

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
