### PR TITLE
Delete FCM instanceID when unregistering - iOS

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -119,10 +119,20 @@
             NSLog(@"unsubscribe from topic: %@", topic);
             [pubSub unsubscribeFromTopic:topic];
         }
+    } else if ([self usesFCM]) {
+        [[FIRInstanceID instanceID] deleteIDWithHandler:^void(NSError *_Nullable error){
+            if (error) {
+                // failed to delete the identity for the app
+                [self failWithMessage:command.callbackId withMsg:@"" withError:error];
+            } else {
+                // deleted the identity for the app successfully
+                [self successWithMessage:command.callbackId withMsg:@"unregistered"];
+            }
+        }];
     } else {
         [[UIApplication sharedApplication] unregisterForRemoteNotifications];
         [self successWithMessage:command.callbackId withMsg:@"unregistered"];
-    }
+    }  
 }
 
 - (void)subscribe:(CDVInvokedUrlCommand*)command;

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -119,20 +119,19 @@
             NSLog(@"unsubscribe from topic: %@", topic);
             [pubSub unsubscribeFromTopic:topic];
         }
-    } else if ([self usesFCM]) {
+    } else if ([self usesFCM]){
         [[FIRInstanceID instanceID] deleteIDWithHandler:^void(NSError *_Nullable error){
             if (error) {
-                // failed to delete the identity for the app
                 [self failWithMessage:command.callbackId withMsg:@"" withError:error];
             } else {
-                // deleted the identity for the app successfully
                 [self successWithMessage:command.callbackId withMsg:@"unregistered"];
             }
         }];
-    } else {
+    }
+    else {
         [[UIApplication sharedApplication] unregisterForRemoteNotifications];
         [self successWithMessage:command.callbackId withMsg:@"unregistered"];
-    }  
+    }
 }
 
 - (void)subscribe:(CDVInvokedUrlCommand*)command;


### PR DESCRIPTION
## Description
FCM Instance ID will be deleted when unregistering. Added some code to check registered with FCM and delete the token if so.

## Related Issue
#2082 

## Motivation and Context
I need to refresh FCM token in certain scenarios. But unregistering and registering again returns the same token. But with this change FCM instance ID will be deleted when unregistered. If you try to send a push notification after unregistering, you will get an "Not registered" error from fcm end-point (which should be the correct behavior I guess). 

## How Has This Been Tested?
Tested on a iPhone 6 (OS version 11.4).
Positive scenario:
Registered/unregistered multiple times. Got a new ID every time as expected. Sent notifications to all tokens. Notifications to the active token worked. Rest failed with "Not registered".
Negative scenario:
error callback was called if no network connection during unregistering.

##Note
Please review the pull request carefully since I am a Objective C noob.
