### PR TITLE
clearAll notifications on Android if count zero when in background

### DIFF
--- a/docs/PAYLOAD.md
+++ b/docs/PAYLOAD.md
@@ -60,6 +60,8 @@ The following flowchart attempts to give you a picture of what happens when a pu
 - If the app is running in the background the push plugin then checks to see if `content-available` exists in the push data.
 - If `content-available` is set to `1`, then the plugin calls all of your `notification` event handlers.
 
+> Note: if `count` is given as `0` then all notifications are first cleared: always on Android, and if the `count` has gone down on iOS
+
 ## User clicks on notification in notification center
 
 - The app starts.

--- a/src/android/com/adobe/phonegap/push/FCMService.java
+++ b/src/android/com/adobe/phonegap/push/FCMService.java
@@ -329,6 +329,10 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
       Log.d(LOG_TAG, "count =[" + badgeCount + "]");
       PushPlugin.setApplicationIconBadgeNumber(context, badgeCount);
     }
+    if (badgeCount == 0) {
+      NotificationManager mNotificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+      mNotificationManager.cancelAll();
+    }
 
     Log.d(LOG_TAG, "message =[" + message + "]");
     Log.d(LOG_TAG, "title =[" + title + "]");


### PR DESCRIPTION
## Description

Update FCMService notification handler for Android when in background so count==0 initially clears all existing notifications, closely matching iOS functionality.  Note that iOS only clears notifications if the count has gone down eg from 1 to 0. Notifications are not cleared if count not given.

Update payload documentation with note to explain behaviour on Android and iOS.
Please change or move the note if required.

## Related Issue

https://github.com/phonegap/phonegap-plugin-push/issues/2520

## Motivation and Context

If notification(s) are no longer relevant then they should be removed, even if app not running.
This can be signalled by setting badge count to zero.

This was not happening in Android.

Note that after all current notifications have been cleared (a) a new notification will be created if a message or title is given and (b) the notification event handlers are called if the app is running.

## How Has This Been Tested?

Tested by sending notifications with different payloads to Android and iOS devices.

## Types of changes
The change could be viewed as one or all of these types:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
