### PR TITLE
Update TYPESCRIPT.md

### DIFF
--- a/docs/TYPESCRIPT.md
+++ b/docs/TYPESCRIPT.md
@@ -1,7 +1,6 @@
-# Typescript definition file
+# Typescript definitions
 
-For those of you who use typescript, we're glad to say that we have the complete definition file available at [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped).
-Search for `phonegap-plugin-push` there, or simply grab it directly [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/phonegap-plugin-push/index.d.ts).
+For those of you who use Typescript, we're glad to say that we provide the complete definition file along with our package.
 
 ## Example usage
 
@@ -9,6 +8,8 @@ All objects will be understood as having a defined type, including init options 
 All available attributes and properties will have autocomplete support and type checkings.
 
 ```typescript
+import 'phonegap-plugin-push/types';
+
 const push = PushNotification.init({
 	android: {
 	},
@@ -64,8 +65,3 @@ push.on('notification', (data: my.custom.NotificationEventResponse) => {
 	console.log(data.additionalData.bacon);
 });
 ```
-
-## Outdated definitions
-
-Is our definition file at DefinitelyTyped outdated? Is there any improvements that could be done?
-We welcome any contribution, and they should be done through issues created [there](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/new).


### PR DESCRIPTION
## Description

The type declarations for this plugin come with the package now, [`@types/phonegap-plugin-push`](https://www.npmjs.com/@types/phonegap-plugin-push) has been deprecated.

The example also didn't show how to actually import the types.

## Related Issue

Nope.

## Motivation and Context

I needed to use this plugin in a Typescript project and saw that this doc was outdated.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
