### PR TITLE
Added Channel Group

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -5,6 +5,9 @@
 - [.createChannel() - Android only](#pushnotificationcreatechannel)
 - [.deleteChannel() - Android only](#pushnotificationdeletechannel)
 - [.listChannels() - Android only](#pushnotificationlistchannels)
+- [.createChannelGroup() - Android only](#pushnotificationcreatechannelgroup)
+- [.deleteChannelGroup() - Android only](#pushnotificationdeletechannelgroup)
+- [.listChannelGroups() - Android only](#pushnotificationlistchannelgroups)
 - [push.on()](#pushonevent-callback)
   - [push.on('registration')](#pushonregistration-callback)
   - [push.on('notification')](#pushonnotification-callback)
@@ -224,6 +227,7 @@ A default channel with the id "PushPluginChannel" is created automatically. To m
 | `sound`                          | `String`  | The name of the sound file to be played upon receipt of the notification in this channel. Cannot be changed after channel is created.                                                                                               |
 | `vibration`                      | `Boolean` or `Array` | Boolean sets whether notification posted to this channel should vibrate. Array sets custom vibration pattern. Example - vibration: `[2000, 1000, 500, 500]`. Cannot be changed after channel is created.                 |
 | `visibility`                     | `Int`     | Sets whether notifications posted to this channel appear on the lockscreen or not, and if so, whether they appear in a redacted form. 0 = Private, 1 = Public, -1 = Secret.                                                         |
+| `group_id`                     | `String`     | Sets channel group id. Assign it to a Channel Group Created. Cannot be changed once set.                                                         |
 
 ## PushNotification.deleteChannel(successHandler, failureHandler, channelId)
 
@@ -274,10 +278,110 @@ Returns a list of currently configured channels.
 ```javascript
 PushNotification.listChannels(channels => {
   for (let channel of channels) {
-    console.log(`ID: ${channel.id} Description: ${channel.description}`);
+    console.log(`ID: ${channel.id} Description: ${channel.description} GroupID: ${channel.group_id}`);
   }
 });
 ```
+
+## PushNotification.createChannelGroup(successHandler, failureHandler, channel)
+
+Create a new notification channel group for Android O and above.
+
+### Parameters
+
+| Parameter        | Type       | Default | Description                                            |
+| ---------------- | ---------- | ------- | ------------------------------------------------------ |
+| `successHandler` | `Function` |         | Is called when the api successfully creates a channel. |
+| `failureHandler` | `Function` |         | Is called when the api fails to create a channel.      |
+| `channelGroup`   | `Object`   |         | The options for the channel group.                           |
+
+### Example
+
+```javascript
+PushNotification.createChannelGroup(
+  () => {
+    console.log('success');
+  },
+  () => {
+    console.log('error');
+  },
+  {
+    id: 'testchannelgroup',
+    name: 'My first test channel group'
+  }
+);
+```
+
+The above will create a channel group for your app. You'll need to provide the `id` and `name` properties. 
+
+
+
+### Channel Group properties
+
+| Property                         | Type      | Description                                                                                                                                                                                                                         |
+| -------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                             | `String`  | The id of the channel group.                                                         |
+| `name`                           | `String`  | The user visible name of the channel group.                                          |
+
+## PushNotification.deleteChannelGroup(successHandler, failureHandler, channelGroupId)
+
+Delete a notification channel for Android O and above.
+
+### Parameters
+
+| Parameter        | Type       | Default | Description                                                  |
+| ---------------- | ---------- | ------- | ------------------------------------------------------------ |
+| `successHandler` | `Function` |         | Is called when the api successfully creates a channel group. |
+| `failureHandler` | `Function` |         | Is called when the api fails to create a channel group.      |
+| `channelGroupId` | `String`   |         | The ID of the channel group.                                 |
+
+### Example
+
+```javascript
+PushNotification.deleteChannelGroup(
+  () => {
+    console.log('success');
+  },
+  () => {
+    console.log('error');
+  },
+  'testchannelgroup'
+);
+```
+
+## PushNotification.listChannelGroups(successHandler)
+
+Returns a list of currently configured channel groups.
+
+### Parameters
+
+| Parameter        | Type       | Default | Description                                                         |
+| ---------------- | ---------- | ------- | ------------------------------------------------------------------- |
+| `successHandler` | `Function` |         | Is called when the api successfully retrieves the list of channels. |
+
+### Callback parameters
+
+#### `successHandler`
+
+| Parameter       | Type         | Description                    |
+| ----------      | ------------ | ------------------------------ |
+| `channelGroups` | `JSONArrary` | List of channel group objects. |
+
+### Example
+
+```javascript
+PushNotification.listChannelGroups(channelGroups => {
+  for (let channelGroup of channelGroups) {
+    console.log(`ID: ${channelGroup.id} Description: ${channelGroup.name}`);
+  }
+});
+```
+
+
+
+
+
+       
 
 ## push.on(event, callback)
 

--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -102,4 +102,10 @@ public interface PushConstants {
   public static final String ONGOING = "ongoing";
   public static final String LIST_CHANNELS = "listChannels";
   public static final String CLEAR_NOTIFICATION = "clearNotification";
+  public static final String CREATE_CHANNEL_GROUP = "createChannelGroup";
+  public static final String LIST_CHANNEL_GROUPS = "listChannelGroups";
+  public static final String DELETE_CHANNEL_GROUP = "deleteChannelGroup";
+  public static final String GROUP_ID = "id";
+  public static final String GROUP_NAME= "name";
+  public static final String CHANNEL_GROUP_ID = "group_id";
 }

--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -69,6 +69,7 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
         JSONObject channel = new JSONObject();
         channel.put(CHANNEL_ID, notificationChannel.getId());
         channel.put(CHANNEL_DESCRIPTION, notificationChannel.getDescription());
+        channel.put(CHANNEL_GROUP_ID, notificationChannel.getGroup());
         channels.put(channel);
       }
     }
@@ -96,7 +97,12 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
       NotificationChannel mChannel = new NotificationChannel(channel.getString(CHANNEL_ID),
           channel.optString(CHANNEL_DESCRIPTION, ""),
           channel.optInt(CHANNEL_IMPORTANCE, NotificationManager.IMPORTANCE_DEFAULT));
-
+      
+      String groupId=channel.optString(CHANNEL_GROUP_ID, "");
+            if(groupId != null && !groupId.isEmpty() ) {
+                mChannel.setGroup(groupId);
+      }
+      
       int lightColor = channel.optInt(CHANNEL_LIGHT_COLOR, -1);
       if (lightColor != -1) {
         mChannel.setLightColor(lightColor);

--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -164,6 +164,45 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
       }
     }
   }
+  
+  @TargetApi(26)
+  private void createChannelGroup(JSONObject group) throws JSONException {
+        // only call on Android O and above
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            final NotificationManager notificationManager = (NotificationManager) cordova.getActivity()
+            .getSystemService(Context.NOTIFICATION_SERVICE);
+            NotificationChannelGroup mGroup = new NotificationChannelGroup(group.optString(GROUP_ID, ""), group.optString(GROUP_NAME, ""));
+            notificationManager.createNotificationChannelGroup(mGroup);
+        }
+    }
+    
+    @TargetApi(26)
+    private JSONArray listChannelGroups() throws JSONException {
+        JSONArray channelGroups = new JSONArray();
+        // only call on Android O and above
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            final NotificationManager notificationManager = (NotificationManager) cordova.getActivity()
+            .getSystemService(Context.NOTIFICATION_SERVICE);
+            List<NotificationChannelGroup> notificationChannelGroups = notificationManager.getNotificationChannelGroups();
+            for (NotificationChannelGroup notificationChannelGroup : notificationChannelGroups) {
+                JSONObject channelGroup = new JSONObject();
+                channelGroup.put(GROUP_ID, notificationChannelGroup.getId());
+                channelGroup.put(GROUP_NAME, notificationChannelGroup.getName());
+                channelGroups.put(channelGroup);
+            }
+        }
+    return channelGroups;
+    }
+    
+    @TargetApi(26)
+    private void deleteChannelGroup(String channelGroupId) {
+        // only call on Android O and above
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            final NotificationManager notificationManager = (NotificationManager) cordova.getActivity()
+            .getSystemService(Context.NOTIFICATION_SERVICE);
+            notificationManager.deleteNotificationChannelGroup(channelGroupId);
+        }
+    }
 
   @Override
   public boolean execute(final String action, final JSONArray data, final CallbackContext callbackContext) {
@@ -431,7 +470,45 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
           }
         }
       });
-    } else {
+    } else if (CREATE_CHANNEL_GROUP.equals(action)) {
+             // un-subscribing for a topic
+            cordova.getThreadPool().execute(new Runnable() {
+                public void run() {
+                  try {
+                    // call create channel
+                    createChannelGroup(data.getJSONObject(0));
+                    callbackContext.success();
+                  } catch (JSONException e) {
+                    callbackContext.error(e.getMessage());
+                  }
+                }
+              });
+        } else if (LIST_CHANNEL_GROUPS.equals(action)) {
+             // un-subscribing for a topic
+            cordova.getThreadPool().execute(new Runnable() {
+                public void run() {
+                  try {
+                    callbackContext.success(listChannelGroups());
+                  } catch (JSONException e) {
+                    callbackContext.error(e.getMessage());
+                  }
+                }
+              });
+        } else if (DELETE_CHANNEL_GROUP.equals(action)) {
+              // un-subscribing for a topic
+              cordova.getThreadPool().execute(new Runnable() {
+                public void run() {
+                  try {
+                    String channelGroupId = data.getString(0);
+                    deleteChannelGroup(channelGroupId);
+                    callbackContext.success();
+                  } catch (JSONException e) {
+                    callbackContext.error(e.getMessage());
+                  }
+                }
+              });
+        } 
+    else {
       Log.e(LOG_TAG, "Invalid action : " + action);
       callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
       return false;

--- a/src/js/push.js
+++ b/src/js/push.js
@@ -337,6 +337,18 @@ module.exports = {
   listChannels: (successCallback, errorCallback) => {
     exec(successCallback, errorCallback, 'PushNotification', 'listChannels', []);
   },
+  createChannelGroup: (successCallback, errorCallback, channelGroup) {
+    exec(successCallback, errorCallback, 'PushNotification', 'createChannelGroup', [channelGroup]);
+  },
+
+  deleteChannelGroup: (successCallback, errorCallback, channelGroupId) {
+    exec(successCallback, errorCallback, 'PushNotification', 'deleteChannelGroup', [channelGroupId]);
+  },
+    
+  listChannelGroups: (successCallback, errorCallback) {
+    exec(successCallback, errorCallback, 'PushNotification', 'listChannelGroups', []);
+  },
+
 
   /**
    * PushNotification Object.

--- a/www/push.js
+++ b/www/push.js
@@ -381,6 +381,19 @@ module.exports = {
   listChannels: function listChannels(successCallback, errorCallback) {
     exec(successCallback, errorCallback, 'PushNotification', 'listChannels', []);
   },
+  
+  createChannelGroup: function createChannel(successCallback, errorCallback, channelGroup) {
+    exec(successCallback, errorCallback, 'PushNotification', 'createChannelGroup', [channelGroup]);
+  },
+
+  deleteChannelGroup: function deleteChannel(successCallback, errorCallback, channelGroupId) {
+    exec(successCallback, errorCallback, 'PushNotification', 'deleteChannelGroup', [channelGroupId]);
+  },
+
+  listChannelGroups: function listChannels(successCallback, errorCallback) {
+    exec(successCallback, errorCallback, 'PushNotification', 'listChannelGroups', []);
+  },
+
 
   /**
    * PushNotification Object.


### PR DESCRIPTION


## Description
In Android O,Push Channel also have group to categorize notification channel such as Work and Personal Notifications  

## Motivation and Context
It can help user to assign notification channel to a group,easily categorizing it

## How Has This Been Tested?
Using Outsystem,I use the Firebase Push Plugin and modified the source code and the wrapper on the plugin on Outsystem itself with the channels related function in the latest version of this plugin.
Also tested on Mi Max on lineageOS 15.1 and Mi A1 on Android 8.0 for creation,listing and deletion of channel.Setting and listing channels with the group



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
