### PR TITLE
Issue 2585 - Alllowing to clear notification when the app is not running

### DIFF
--- a/src/android/com/adobe/phonegap/push/FCMService.java
+++ b/src/android/com/adobe/phonegap/push/FCMService.java
@@ -103,8 +103,13 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
         PushPlugin.setApplicationIconBadgeNumber(getApplicationContext(), 0);
       }
 
+      int clearNotificationId = getClearNotificationId(extras);
+
+      // if the notification has a `clearNotification`, then clear it.
+      if(clearNotificationId != -1) {
+        PushPlugin.clearNotification(getApplicationContext(), clearNotificationId);
       // if we are in the foreground and forceShow is `false` only send data
-      if (!forceShow && PushPlugin.isInForeground()) {
+      } else if (!forceShow && PushPlugin.isInForeground()) {
         Log.d(LOG_TAG, "foreground");
         extras.putBoolean(FOREGROUND, true);
         extras.putBoolean(COLDSTART, false);
@@ -300,6 +305,20 @@ public class FCMService extends FirebaseMessagingService implements PushConstant
     } // while
 
     return newExtras;
+  }
+
+  private int getClearNotificationId(Bundle extras) {
+    int clearNotificationId = -1;
+    String msgcnid = extras.getString(CLEAR_NOTIFICATION);
+
+    try {
+      if (msgcnid != null) {
+        clearNotificationId = Integer.parseInt(msgcnid);
+      }
+    } catch (NumberFormatException e) {
+      Log.e(LOG_TAG, e.getLocalizedMessage(), e);
+    }
+    return clearNotificationId;
   }
 
   private int extractBadgeCount(Bundle extras) {

--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -534,10 +534,13 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
   }
 
   private void clearNotification(int id) {
-    final NotificationManager notificationManager = (NotificationManager) cordova.getActivity()
-        .getSystemService(Context.NOTIFICATION_SERVICE);
-    String appName = (String) this.cordova.getActivity().getPackageManager()
-        .getApplicationLabel(this.cordova.getActivity().getApplicationInfo());
+    PushPlugin.clearNotification(cordova.getActivity(), id);
+  }
+
+  public static void clearNotification(Context context, int id) {
+    final NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+    String appName = (String) context.getPackageManager()
+      .getApplicationLabel(context.getApplicationInfo());
     notificationManager.cancel(appName, id);
   }
 

--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -83,7 +83,6 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
 
     // app is in the background or inactive, so only call notification callback if this is a silent push
     if (application.applicationState != UIApplicationStateActive) {
-
         NSLog(@"app in-active");
 
         // do some convoluted logic to find out if this should be a silent push.
@@ -108,6 +107,13 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
 
             if (pushHandler.handlerObj == nil) {
                 pushHandler.handlerObj = [NSMutableDictionary dictionaryWithCapacity:2];
+            }
+
+            // Check if this is a clear notification.
+            id clearNotification = [userInfo objectForKey:@"clearNotification"];
+            if ([clearNotification isKindOfClass:[NSString class]]) {
+                NSNumber *clearNotificationId = @([clearNotification integerValue]);
+                [pushHandler clearRealNotification: clearNotificationId];
             }
 
             id notId = [userInfo objectForKey:@"notId"];
@@ -154,7 +160,7 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
 - (void)pushPluginOnApplicationDidBecomeActive:(NSNotification *)notification {
 
     NSLog(@"active");
-    
+
     NSString *firstLaunchKey = @"firstLaunchKey";
     NSUserDefaults *defaults = [[NSUserDefaults alloc] initWithSuiteName:@"phonegap-plugin-push"];
     if (![defaults boolForKey:firstLaunchKey]) {

--- a/src/ios/PushPlugin.h
+++ b/src/ios/PushPlugin.h
@@ -61,6 +61,8 @@
 - (void)unsubscribe:(CDVInvokedUrlCommand*)command;
 - (void)clearNotification:(CDVInvokedUrlCommand*)command;
 
+- (void)clearRealNotification:(NSNumber*)notId;
+
 - (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 - (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
 

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -442,11 +442,6 @@
             }
         }
 
-        if([additionalData objectForKey:@"clearNotification") {
-            NSNumber *clearNotificationId = @([[additionalData objectForKey:@"clearNotification"] integerValue]);
-            [clearRealNotification: clearNotificationId];
-        }
-
         if (isInline) {
             [additionalData setObject:[NSNumber numberWithBool:YES] forKey:@"foreground"];
         } else {
@@ -485,17 +480,17 @@
             [matchingNotificationIdentifiers addObject:notification.request.identifier];
         }
         [[UNUserNotificationCenter currentNotificationCenter] removeDeliveredNotificationsWithIdentifiers:matchingNotificationIdentifiers];
-
-        NSString *message = [NSString stringWithFormat:@"Cleared notification with ID: %@", notId];
-        CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:message];
-        [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
     }];
 }
 
 - (void)clearNotification:(CDVInvokedUrlCommand *)command
 {
     NSNumber *notId = [command.arguments objectAtIndex:0];
-    [clearRealNotification: notId];
+    [self clearRealNotification: notId];
+
+    NSString *message = [NSString stringWithFormat:@"Cleared notification with ID: %@", notId];
+    CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:message];
+    [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
 }
 
 - (void)setApplicationIconBadgeNumber:(CDVInvokedUrlCommand *)command

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -442,6 +442,11 @@
             }
         }
 
+        if([additionalData objectForKey:@"clearNotification") {
+            NSNumber *clearNotificationId = @([[additionalData objectForKey:@"clearNotification"] integerValue]);
+            [clearRealNotification: clearNotificationId];
+        }
+
         if (isInline) {
             [additionalData setObject:[NSNumber numberWithBool:YES] forKey:@"foreground"];
         } else {
@@ -466,9 +471,8 @@
     }
 }
 
-- (void)clearNotification:(CDVInvokedUrlCommand *)command
+- (void)clearRealNotification:(NSNumber *)notId
 {
-    NSNumber *notId = [command.arguments objectAtIndex:0];
     [[UNUserNotificationCenter currentNotificationCenter] getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> * _Nonnull notifications) {
         /*
          * If the server generates a unique "notId" for every push notification, there should only be one match in these arrays, but if not, it will delete
@@ -481,11 +485,17 @@
             [matchingNotificationIdentifiers addObject:notification.request.identifier];
         }
         [[UNUserNotificationCenter currentNotificationCenter] removeDeliveredNotificationsWithIdentifiers:matchingNotificationIdentifiers];
-        
+
         NSString *message = [NSString stringWithFormat:@"Cleared notification with ID: %@", notId];
         CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:message];
         [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
     }];
+}
+
+- (void)clearNotification:(CDVInvokedUrlCommand *)command
+{
+    NSNumber *notId = [command.arguments objectAtIndex:0];
+    [clearRealNotification: notId];
 }
 
 - (void)setApplicationIconBadgeNumber:(CDVInvokedUrlCommand *)command


### PR DESCRIPTION
***NOTE***: iOS hasn't been tested yet because of #2617. I am delivering the PR nonetheless for discussions and possible changes if needed. When I am able to do the usecase described in #2617 I will be able to test iOS and fix any mistakes if needed.

## Description
I added an extra optional key to the payload `clearNotification`, this key can be used to clear notificitations that have said `notId`.
For example:
```javascript
// Send first notificitation
firstPayload = {
        'title': 'Clear notification',
        'body': 'Test body',
        'notId': '1337
};
// Send second notification to clear it
secondPayload = {
        'title': 'Clear notification',
        'body': 'Test body',
        'clearNotification': '1337'
};
```
The changes are quite simple, for Android I added an extra check if the `clearNotification` key is available, if so then we simple remove the notification with that ID. I did change the `clearNotification()` method. I move the functionality to a static method. That way anyone that has acces can call the method while the cordova bridge is still intact.

For iOS basically the same thing except that I moved the `clearNotification()` functionality to `clearRealNotification()` so it can be used by anyone that has acccsm, and still keeping the cordova bridge intact.

## Related Issue
#2585

## Motivation and Context
This allows developers to remove notification from the notification tray without their user having the app open/running.

And here are some [use-cases](https://github.com/phonegap/phonegap-plugin-push/issues/2585#issuecomment-434958216) for this functionality describe by an other user.

## How Has This Been Tested?
I tested this by sending above payload through FCM towards my devices. Android functionality hasn't changed much, I tested the push and the cordova bridge and both are still working as expected.

iOS testing *HAS NOT BEEN DONE YET* because of #2617. Because the `clearNotification` is in the same method as the `notId`, I haven't been able to test it yet.

Documentation is also not done because I wasn't sure where to put the new information, if anyone can point me in that direction, much appreciated.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
