### PR TITLE
Fix an issue where the application is not receiving callbacks for actions.

### DIFF
--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -215,7 +215,7 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
         case UIApplicationStateInactive:
         {
             NSLog(@"coldstart");
-            self.launchNotification = response.notification.request.content.userInfo;
+            self.launchNotification = userInfo;
             self.coldstart = [NSNumber numberWithBool:YES];
             break;
         }


### PR DESCRIPTION
A mutable copy of the userInfo object is created and the actionCallback is then set into the copy, but the copy is not used in the case where the application is inactive, so the action is not recognized on launch.

## How Has This Been Tested?
Tested using our current app (Pacifica) in a development environment to verify that the action callbacks are fired with my change.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
