### PR TITLE
:bug: Issue #2630: Fix initialisation of gForeground when started in …

### DIFF
--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -499,7 +499,8 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
   @Override
   public void initialize(CordovaInterface cordova, CordovaWebView webView) {
     super.initialize(cordova, webView);
-    gForeground = true;
+    boolean startInBackground = cordova.getActivity().getIntent().getExtras().getBoolean(START_IN_BACKGROUND,false);
+    gForeground = !startInBackground;
   }
 
   @Override


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
Fix initialisation of plugin to handle the case where the app is launched in the background.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue #2630 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When currently launched in the background, the plugin incorrectly thinks it is in the foreground and absorbs notifications instead of sending them to the shade.  This behaviour continues indefinitely until the app is brought into the foreground by the user at which point the app and plugin state get back into sync.

The fix keeps the plugin gForeground state flag in sync with the app at all times.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested as described in my comments in Issue #2630:

Using the following msg:
```
fsmsg =
  data:
    'force-start': 1
    title: 'forced'
    message: 'any message'
```
1. With the app not running, send fsmsg notification.
2. Phone receives the notification which is shown in the shade, and the app is launched in the background.
3. Do NOT bring the app to the foreground.
4. Send fsmsg again.  The phone should indicate that the notification has been received (without the fix it doesn't).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
