### PR TITLE
on notification ios does not work on cold start

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -28,8 +28,8 @@
 
 #import "PushPlugin.h"
 #import "AppDelegate+notification.h"
+@import Firebase;
 @import FirebaseInstanceID;
-@import FirebaseMessaging;
 @import FirebaseAnalytics;
 
 @implementation PushPlugin : CDVPlugin
@@ -155,6 +155,18 @@
         NSLog(@"There is no topic to unsubscribe");
         [self successWithMessage:command.callbackId withMsg:@"There is no topic to unsubscribe"];
     }
+}
+
+- (void)pluginInitialize
+{
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(finishLaunching:) name:UIApplicationDidFinishLaunchingNotification object:nil];
+
+}
+
+- (void)finishLaunching:(NSNotification *)notification
+{
+    NSLog(@"finishLaunching called");
+    self.notificationMessage = notification.userInfo;
 }
 
 - (void)init:(CDVInvokedUrlCommand*)command;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Reimplemented the cold start logic from an old version (the ~1.0.0.)
Maybe the code was lost during various merges.
+ Changed the Firebase import to allow correct code compile.

## Related Issue
https://github.com/phonegap/phonegap-plugin-push/issues/2629

## Motivation and Context
on('notification') handler now will be called also on cold start. (When app is inactive)

## How Has This Been Tested?
Real project in production.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
