### PR TITLE
Browser webpush

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -56,10 +56,9 @@ All available option attributes are described bellow. Currently, there are no Wi
 
 #### Browser
 
-| Attribute                      | Type     | Default                                                      | Description                                             |
-| ------------------------------ | -------- | ------------------------------------------------------------ | ------------------------------------------------------- |
-| `browser.pushServiceURL`       | `string` | `http://push.api.phonegap.com/v1/push`                       | Optional. URL for the push server you want to use.      |
-| `browser.applicationServerKey` | `string` |                                                              | Optional. Your GCM API key if you are using VAPID keys. |
+| Attribute                      | Type     | Default                                                      | Description                                                                     |
+| ------------------------------ | -------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------- |
+| `browser.applicationServerKey` | `string` |                                                              | Optional. Your VAPID public key / Firebase Cloud Messaging Web Push Certificate |
 
 #### iOS
 
@@ -140,7 +139,7 @@ The "finish" method has not use too when the VoIP notifications are enabled.
 const push = PushNotification.init({
   android: {},
   browser: {
-    pushServiceURL: 'http://push.api.phonegap.com/v1/push'
+    applicationServerKey: '...'
   },
   ios: {
     alert: 'true',
@@ -294,10 +293,11 @@ The event `registration` will be triggered on each successful registration with 
 
 ### Callback parameters
 
-| Parameter               | Type     | Description                                                                     |
-| ----------------------- | -------- | ------------------------------------------------------------------------------- |
-| `data.registrationId`   | `string` | The registration ID provided by the 3rd party remote push service.              |
-| `data.registrationType` | `string` | The registration type of the 3rd party remote push service. Either FCM or APNS. |
+| Parameter               | Type     | Description                                                                               |
+| ----------------------- | -------- | ----------------------------------------------------------------------------------------- |
+| `data.registrationId`   | `string` | The registration ID provided by the 3rd party remote push service.                        |
+| `data.registrationType` | `string` | The registration type of the 3rd party remote push service. Either FCM, APNS or WEB_PUSH. |
+| `data.subscription`     | `string` | Browser only. A JSON object provided by the browser containing subscription details.      |
 
 ### Example
 
@@ -305,6 +305,7 @@ The event `registration` will be triggered on each successful registration with 
 push.on('registration', data => {
   console.log(data.registrationId);
   console.log(data.registrationType);
+  console.log(data.subscription);
 });
 ```
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -12,9 +12,9 @@ phonegap create my-app --template phonegap-template-push
 const push = PushNotification.init({
 	android: {
 	},
-    browser: {
-        pushServiceURL: 'http://push.api.phonegap.com/v1/push'
-    },
+	browser: {
+		applicationServerKey: "..."
+	},
 	ios: {
 		alert: "true",
 		badge: "true",
@@ -24,7 +24,9 @@ const push = PushNotification.init({
 });
 
 push.on('registration', (data) => {
-	// data.registrationId
+	// data.registrationType,
+	// data.registrationId,
+	// data.subscription (on browser platform) 
 });
 
 push.on('notification', (data) => {
@@ -40,3 +42,120 @@ push.on('error', (e) => {
 	// e.message
 });
 ```
+## Browser Web Push
+
+Some users may wish to use `phonegap-plugin-push` to deliver push notifications to browsers via a 
+[WebPush](https://tools.ietf.org/html/rfc8030) compliant service, such as:
+ 
+ * [Firebase Cloud Messaging](https://firebase.google.com/docs/cloud-messaging/) (FCM) for  Chrome and Samsung browser
+ * [Mozilla Cloud Services](https://support.mozilla.org/en-US/kb/push-notifications-firefox) (MCS)  for Mozilla Firefox
+ * [Windows Push Notification Services](https://docs.microsoft.com/en-us/windows/uwp/design/shell/tiles-and-notifications/windows-push-notification-services--wns--overview) (WNS) for Microsoft Edge
+
+The plumbing for WebPush is quite complex, so we'll walk through an example of how to set it up. We'll create the 
+following baseline artifacts to spin up a basic WebPush service:
+
+* **A VAPID public key:** to register our browser with the browser vendor's push platform (i.e. FCM, MCS, WNS)
+* **A `PushNotification` `registration` event handler** to pass the vendor endpoint details to our web app after our browser has registered with the vendor's push platform
+* **A service worker** to process incoming notifications from the vendor's push platform
+
+We'll be using FCM to generate our VAPID key, but you could also get 
+one elsewhere or generate your own - the approach is vendor neutral.
+
+#### VAPID public key
+
+VAPID stands for 
+[_Voluntary Application Server Identification for Web Push_](https://datatracker.ietf.org/doc/draft-ietf-webpush-vapid/).
+A _VAPID public key_ is a Base64 string containing an encryption key that the vendor push platform (FCM, MCS, WNS) will use to 
+authenticate your application server. 
+
+If you're using FCM you can generate a VAPID public key by browsing to your project home and 
+selecting _Settings_ > _Cloud Messaging_ > _Web Configuration_ > _Web Push certificates_ and generating a key pair.
+
+The Base64 string under the heading 'key pair' is what needs to go into your `PushNotification.init` configuration as 
+the browser platform's `applicationServerKey`:
+```
+{
+  ...
+  browser: {
+    applicationServerKey: '<VAPID PUBLIC KEY GOES HERE>'
+  },
+  ...
+}
+```
+
+#### Registration event handler
+
+Calling `PushNotification.init` from a browser when an `applicationServerKey` is provided will trigger an attempt to 
+subscribe the browser instance to its vendor's push service (FCM for Chrome, MCS for Firefox, WNS for Edge).
+
+If our attempt to register with the vendor's push platform is successful, it triggers a `registration` event from 
+`PushNotification`. The payload for the `registration` event is a dict that describes our subscription endpoint on the vendor's push
+platform. It will look similar to the dicts you receive for iOS and Android, but with an additional `subscription` 
+element. For example:
+```
+{
+  "registrationType": "WEB_PUSH",
+  "registrationId": "blahblahblah",
+  "subscription": { 
+    "endpoint": "https://fcm.googleapis.com/fcm/send/blahblah:blahblahblah",
+    "expirationTime":null,
+    "keys": {
+      "p256dh": "blahblahblah"
+    }
+  }
+}
+```
+Our server-side code needs this data to send a notification to that user. We can post it to our server API when the 
+`registration` event fires:
+```
+const push = PushNotification.init({
+  // Your push configuration
+});
+
+push.on('registration', regData => {
+  ...
+  axios('https://api.myservice.com/webpush/subscriptions', {
+    headers: {' content-type': 'application/json' },
+    method: 'POST',
+    data: regData,
+  })
+    .then(resp => ...)
+    .catch(err => ...);
+  ...
+}));
+```
+We can then store the user's subscription data on our server along with the user's ID, and retrieve it when we want to push 
+a notification to that user. 
+
+Pushing a notification from our server to the user becomes straightforward, especially 
+using a WebPush library like [web-push](https://github.com/web-push-libs/web-push). 
+
+For example, using Node.js:
+```
+const webPush = require('web-push');
+
+const data = <data object posted from client>
+
+await webPush.sendNotification(data.subscription, "This is a test");
+```
+The above code pushes a simple string notification to a specific browser subscription. However, the browser does not 
+yet know what to do with our notifications, so we need to create a service worker that can handle them.
+
+#### Service Worker
+
+To process notifications, we must provide an event handler for `push` events in our app's
+[service worker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) (see how to create a service 
+worker [here](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers)).
+ 
+Here is an example handler that assumes your push payload is a simple string (as sent in the earlier server-side example) and displays it as a standard notification:
+```
+...
+self.addEventListener('push', function (event) {
+  console.log(event.data);
+  event.waitUntil(self.registration.showNotification(event.data));
+});
+...
+``` 
+See your browser's `push` documentation for more details and more complex examples.
+
+Once you've implemented the above patterns you should be able to receive notifications in Chrome-based browsers, Mozilla Firefox and Microsoft Edge.

--- a/docs/PAYLOAD.md
+++ b/docs/PAYLOAD.md
@@ -347,7 +347,7 @@ By default the icon displayed in your push notification will be your apps icon. 
 const push = PushNotification.init({
   android: {},
   browser: {
-    pushServiceURL: 'http://push.api.phonegap.com/v1/push'
+    applicationServerKey: '...'
   },
   ios: {
     alert: 'true',
@@ -388,7 +388,7 @@ const push = PushNotification.init({
     iconColor: 'blue'
   },
   browser: {
-    pushServiceURL: 'http://push.api.phonegap.com/v1/push'
+    applicationServerKey: '...'
   },
   ios: {
     alert: 'true',

--- a/plugin.xml
+++ b/plugin.xml
@@ -57,9 +57,6 @@
     <js-module src="www/browser/push.js" name="BrowserPush">
       <clobbers target="PushNotification"/>
     </js-module>
-    <asset src="src/browser/ServiceWorker.js" target="ServiceWorker.js"/>
-    <asset src="src/browser/manifest.json" target="manifest.json"/>
-    <hook type="after_prepare" src="hooks/browser/updateManifest.js"/>
   </platform>
   <platform name="ios">
     <config-file target="config.xml" parent="/*">

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -168,11 +168,7 @@ declare namespace PhonegapPluginPush {
 		 */
 		browser?: {
 			/**
-			 * URL for the push server you want to use. Default is 'http://push.api.phonegap.com/v1/push'.
-			 */
-			pushServiceURL?: string
-			/**
-			 * Your GCM API key if you are using VAPID keys.
+			 * Your VAPID public key / Firebase Cloud Messaging Web Push Certificate.
 			 */
 			applicationServerKey?: string
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Make WebPush easier and more standardized for the `browser` platform, using same/similar `registration` semantics as iOS and Android. Eliminates hard-wired manifest and service worker injection as well as the hard-wired `pushServiceURL` logic, which made the old code unusable for real-world applications.

These changes will break apps that depend on the plugin's hard-wired manifest, service worker and pushServiceURL logic (a fix, IMHO). If this is a concern for 2.x it would be nice to see a 3.0.alpha soon.

## Description
<!--- Describe your changes in detail -->
#### www/browser/push.js:
* Eliminate injection of `manifest.json` into html `head` element - `manifest.json` should be provided by app
* Eliminate injection of service worker - should be provided by app
* Eliminate push service sub/unsub calls - easier to handle in app based on push.js events, just as in iOS and Android
* Add new `registrationType` of value `WEB_PUSH` to `registration` event to align with iOS/Android push.js
* Add `subscription` element to registration data to pass full browser push subscription dict
* Throw original errors to make debugging easier

#### plugin.xml:
* Eliminate `ServiceWorker.js` and `manifest.json` assets and `after_prepare` hook - should be provided by app

#### API.MD, EXAMPLES.md, PAYLOAD.md
* Updated documentation in line with code changes
* Provided more description of WebPush interaction flow

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2626, #1399

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Makes it easier to use WebPush; eliminates obsolete boilerplate and places responsibility for sub/unsub logic in client code (as is already the case for iOS and Android).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Runs in Chrome, Firefox, Edge.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

It only breaks existing functionality if anyone is using the current pushServiceURL mechanism.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.