### PR TITLE
#2703 IOS: Missing Push Notification Entitlement

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -78,6 +78,9 @@
     <config-file target="*-Release.plist" parent="aps-environment">
       <string>production</string>
     </config-file>
+     <config-file target="*.entitlements" parent="aps-environment">
+      <string>development</string>
+    </config-file>
     <source-file src="src/ios/AppDelegate+notification.m"/>
     <source-file src="src/ios/PushPlugin.m"/>
     <header-file src="src/ios/AppDelegate+notification.h"/>


### PR DESCRIPTION
add missing entitlements

## Description
add missing entitlements

## Related Issue
#2703

## Motivation and Context
Fixes release issue of ios apps

## How Has This Been Tested?
Uploaded build to ios without manualy adding the push entitlement in xcode

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
