### PR TITLE
Clear inbox messages list when clicking action button

### DIFF
--- a/src/android/com/adobe/phonegap/push/BackgroundActionButtonHandler.java
+++ b/src/android/com/adobe/phonegap/push/BackgroundActionButtonHandler.java
@@ -21,6 +21,10 @@ public class BackgroundActionButtonHandler extends BroadcastReceiver implements 
         NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         notificationManager.cancel(FCMService.getAppName(context), notId);
 
+        // Clear list of messages when an action button is clicked.
+        FCMService fcm = new FCMService();
+        fcm.setNotification(notId, "");
+
         if (extras != null)	{
             Bundle originalExtras = extras.getBundle(PUSH_BUNDLE);
 


### PR DESCRIPTION
## Description
Right now, clicking an action button with foreground=false doesn't clear the list of messages of an inbox notification, the only thing it does is dismiss the notification. If you receive a new notification, the full list is displayed again.

With this patch the list is cleared when an action button is clicked. This affects inline replies too.

## Related Issue
https://github.com/phonegap/phonegap-plugin-push/issues/2699

## Motivation and Context
The list of messages should be cleared when clicking an action button, otherwise the user will see the same notifications over and over again.

## How Has This Been Tested?
I didn't find any Jasmine test about inbox notifications, so I tested it manually in:

* Honor 8 with Android 7.
* Android Simulator: Pixel XL with API 27.

The changes are quite small and shouldn't affect other areas of the code.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
