### PR TITLE
Foreground indicator fixed for VoIP notifications

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -621,6 +621,7 @@
 {
     NSLog(@"VoIP Notification received");
     self.notificationMessage = payload.dictionaryPayload;
+    isInline = [UIApplication sharedApplication].applicationState == UIApplicationStateActive;
     [self notificationReceived];
 }
 


### PR DESCRIPTION
Foreground indicator fixed for VoIP notifications

## Description
Foreground attribute in additionaData payload was always false for VoIP notifications. With this 
fix, it takes the properly value.

## Related Issue
https://github.com/phonegap/phonegap-plugin-push/issues/2368

## How Has This Been Tested?
With Xcode 10.

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
