### PR TITLE
:sparkles: Support messaging style for notifications

### DIFF
--- a/docs/PAYLOAD.md
+++ b/docs/PAYLOAD.md
@@ -10,6 +10,7 @@
   - [Sound](#sound)
   - [Stacking](#stacking)
   - [Inbox Stacking](#inbox-stacking)
+  - [Messaging Stacking](#messaging-stacking)
   - [Action Buttons](#action-buttons)
     - [In Line Replies](#in-line-replies)
   - [Led in Notifications](#led-in-notifications)
@@ -965,6 +966,155 @@ You will get an inbox view so you can display multiple notifications in a single
 ![2015-08-25 14 01 35](https://cloud.githubusercontent.com/assets/353180/9468727/2d658bee-4b11-11e5-90fa-248d54c8f3f6.png)
 
 If you use `%n%` in the `summaryText` of the JSON coming down from FCM it will be replaced by the number of messages that are currently in the queue.
+
+## Messaging Stacking
+
+When developing messaging apps, a better alternative to stacking your notifications is to use the messaging style. The style is similar to the inbox stacking, but it also defines a sender name to be displayed next to each message. If the sender name is empty or not provided, no sender will be displayed (this is useful for private conversations). In this If you send the following JSON from FCM:
+
+```json
+{
+  "registration_ids": ["my device id"],
+  "data": {
+    "title": "John Smith",
+    "message": "My first message",
+    "style": "messaging",
+    "image": "https://randomuser.me/api/portraits/men/79.jpg",
+    "image-type": "circle"
+  }
+}
+```
+
+Here is an example using fcm-node that sends the above JSON:
+
+```javascript
+const FCM = require('fcm-node');
+// Replace these with your own values.
+const apiKey = 'replace with API key';
+const deviceID = 'my device id';
+const fcm = new FCM(apiKey);
+
+const message = {
+  to: deviceID,
+  data: {
+    title: 'John Smith',
+    message: 'My first message',
+    style: 'messaging',
+    image: 'https://randomuser.me/api/portraits/men/79.jpg',
+    'image-type': 'circle'
+  }
+};
+
+fcm.send(message, (err, response) => {
+  if (err) {
+    console.log(err);
+    console.log('Something has gone wrong!');
+  } else {
+    console.log('Successfully sent with response: ', response);
+  }
+});
+```
+
+It will produce a notification for an individual conversation:
+
+![2019-04-16 11 15 00](https://user-images.githubusercontent.com/7590321/56197310-d933da80-6038-11e9-887c-edeea100fcc5.png)
+
+The result looks similar to inbox stacking, with the difference that messages won't be truncated to a single line.
+
+If you follow it up with subsequent notifications like:
+
+```json
+{
+  "registration_ids": ["my device id"],
+  "data": {
+    "title": "John Smith",
+    "message": "My second message",
+    "style": "messaging",
+    "image": "https://randomuser.me/api/portraits/men/79.jpg",
+    "image-type": "circle"
+  }
+}
+```
+
+Here is an example using fcm-node that sends the above JSON:
+
+```javascript
+const FCM = require('fcm-node');
+// Replace these with your own values.
+const apiKey = 'replace with API key';
+const deviceID = 'my device id';
+const fcm = new FCM(apiKey);
+
+const message = {
+  to: deviceID,
+  data: {
+    title: 'John Smith',
+    message: 'My second message',
+    style: 'messaging',
+    image: 'https://randomuser.me/api/portraits/men/79.jpg',
+    'image-type': 'circle'
+  }
+};
+
+fcm.send(message, (err, response) => {
+  if (err) {
+    console.log(err);
+    console.log('Something has gone wrong!');
+  } else {
+    console.log('Successfully sent with response: ', response);
+  }
+});
+```
+
+The new message will be added to the current notification.
+
+![2019-04-16 11 15 00](https://user-images.githubusercontent.com/7590321/56197352-f1a3f500-6038-11e9-8616-77f499126914.png)
+
+If you also specify the name of the user that sent the message, it will be displayed next to the message. This is useful for group conversations. If you send the following JSON from FCM:
+
+```json
+{
+  "registration_ids": ["my device id"],
+  "data": {
+    "title": "My Group",
+    "message": "My first message",
+    "style": "messaging",
+    "sender": "John Smith"
+  }
+}
+```
+
+Here is an example using fcm-node that sends the above JSON:
+
+```javascript
+const FCM = require('fcm-node');
+// Replace these with your own values.
+const apiKey = 'replace with API key';
+const deviceID = 'my device id';
+const fcm = new FCM(apiKey);
+
+const message = {
+  to: deviceID,
+  data: {
+    title: 'My Group',
+    message: 'My first message',
+    style: 'messaging',
+    sender: 'John Smith'
+  }
+};
+
+fcm.send(message, (err, response) => {
+  if (err) {
+    console.log(err);
+    console.log('Something has gone wrong!');
+  } else {
+    console.log('Successfully sent with response: ', response);
+  }
+});
+```
+
+It will produce a notification for a group conversation:
+
+![2019-04-16 11 15 00](https://user-images.githubusercontent.com/7590321/56197398-08e2e280-6039-11e9-8119-7be98822bf44.png)
 
 ## Action Buttons
 
@@ -2128,12 +2278,12 @@ On iOS, using the FCM app server protocol, if you are trying to send a silent pu
 		"custom_var_2:" "custom value here" /* Retrieved on app as data.additionalData.custom_var_2 */
 	},
   /* Forces FCM silent push notifications to be triggered in the foreground of your iOS device. */
-  "content_available": true  
+  "content_available": true
 }
 ```
 *Doc modification came in response to @andreszs - Issue [#2449](https://github.com/phonegap/phonegap-plugin-push/issues/2449).
 
-** IMPORTANT: When using the content_available field, Android payload issues may occur. [Read here](../docs/PAYLOAD.md#user-content-use-of-content_available-true) Make sure you separate your Android/iOS server payloads to mitigate any problems that may arise. 
+** IMPORTANT: When using the content_available field, Android payload issues may occur. [Read here](../docs/PAYLOAD.md#user-content-use-of-content_available-true) Make sure you separate your Android/iOS server payloads to mitigate any problems that may arise.
 
 More information on how to send push notifications using the FCM HTTP protocol and payload details can be found here:
 

--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -31,6 +31,7 @@ public interface PushConstants {
   public static final String ALERT = "alert";
   public static final String MESSAGE = "message";
   public static final String BODY = "body";
+  public static final String SENDER = "sender";
   public static final String SOUNDNAME = "soundname";
   public static final String COLOR = "color";
   public static final String LED_COLOR = "ledColor";
@@ -39,6 +40,7 @@ public interface PushConstants {
   public static final String STYLE_INBOX = "inbox";
   public static final String STYLE_PICTURE = "picture";
   public static final String STYLE_TEXT = "text";
+  public static final String STYLE_MESSAGING = "messaging";
   public static final String BADGE = "badge";
   public static final String INITIALIZE = "init";
   public static final String SUBSCRIBE = "subscribe";


### PR DESCRIPTION
## Description
This plugin only supports BigTextStyle, BigPictureStyle and InboxStyle. It should also support MessagingStyle because it's really useful for messaging apps.

## Related Issue
https://github.com/phonegap/phonegap-plugin-push/issues/2742

## Motivation and Context
The messaging style is really useful for messaging apps, I think it's a nice addition to this plugin.

## How Has This Been Tested?
I tested this in a Honor 8 and in several emulators (from Android 8 to Android 5).

## Screenshots (if appropriate):
![2019-04-16 11 15 00](https://user-images.githubusercontent.com/7590321/56197352-f1a3f500-6038-11e9-8616-77f499126914.png)

![2019-04-16 11 15 00](https://user-images.githubusercontent.com/7590321/56197398-08e2e280-6039-11e9-8119-7be98822bf44.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
