### PR TITLE
Restore custom Android permission declaration

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -22,6 +22,8 @@
       <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
       <uses-permission android:name="android.permission.WAKE_LOCK"/>
       <uses-permission android:name="android.permission.VIBRATE"/>
+      <uses-permission android:name="${applicationId}.permission.PushHandlerActivity"></uses-permission>
+      <permission android:name="${applicationId}.permission.PushHandlerActivity" android:protectionLevel="signature"></permission>
     </config-file>
     <config-file target="AndroidManifest.xml" parent="/manifest/application">
       <activity android:name="com.adobe.phonegap.push.PushHandlerActivity" android:exported="true" android:permission="${applicationId}.permission.PushHandlerActivity"/>


### PR DESCRIPTION
Custom Android permission was introduced according to
"Adding custom permission for Push handler Activity #1362".

However, it was found that the permission declaration is
missing after "Merge v2.0.x into master (#1736)".

There is no much sense in requesting a signature level
permission that is not declared in the same application
manifest.

Fix the merge conflict and restore the custom permission
declaration.

<!--- Provide a general summary of your changes in the Title above -->

## Description
No change. Restore previous functionality.

## Related Issue
#1362

## Motivation and Context
Merge conflict resolution.

## How Has This Been Tested?
Local tests do run.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
