### PR TITLE
:apple: run clearBadge logic on main thread to prevent xcode warnings

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -225,7 +225,9 @@
             } else {
                 NSLog(@"PushPlugin.register: setting badge to true");
                 clearBadge = YES;
-                [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
+                });
             }
             NSLog(@"PushPlugin.register: clear badge is set to %d", clearBadge);
 


### PR DESCRIPTION
## Description
I have wrapped `setApplicationIconBadgeNumber` in a `dispatch_async` block on the main thread to prevent the warnings and freezes when registering with the push plugin.

## Related Issue
This is not a new issue, but an old one that never was fixed
https://github.com/phonegap/phonegap-plugin-push/issues/1988

## Motivation and Context
It fixes a warning that also slowed down the initial register call in an app that uses the plugin. After fixing these freezes stopped.

## How Has This Been Tested?
On a iOS device. Main thread checker did not warn afterwards

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
