### PR TITLE
iOS critical alerts

### DIFF
--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -135,7 +135,16 @@ describe('phonegap-plugin-push', function () {
             sound: 'beep',
             image: 'Image',
             additionalData: {},
+            'critical-alert': 1
           });
+        });
+      });
+
+      it('should provide the data[critical-alert] argument', (done) => {
+        var push = PushNotification.init(options);
+        push.on('notification', (data) => {
+          expect(data['critical-alert']).toEqual(1);
+          done();
         });
       });
 

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -1,16 +1,16 @@
 /*
  Copyright 2009-2011 Urban Airship Inc. All rights reserved.
-
+ 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:
-
+ 
  1. Redistributions of source code must retain the above copyright notice, this
  list of conditions and the following disclaimer.
-
+ 
  2. Redistributions in binaryform must reproduce the above copyright notice,
  this list of conditions and the following disclaimer in the documentation
  and/or other materials provided withthe distribution.
-
+ 
  THIS SOFTWARE IS PROVIDED BY THE URBAN AIRSHIP INC``AS IS'' AND ANY EXPRESS OR
  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
@@ -27,10 +27,11 @@
 #define GMP_NO_MODULES true
 
 #import "PushPlugin.h"
-#import "AppDelegate+notification.h"
 @import FirebaseInstanceID;
 @import FirebaseMessaging;
 @import FirebaseAnalytics;
+
+@import UserNotifications;
 
 @implementation PushPlugin : CDVPlugin
 
@@ -54,11 +55,11 @@
 -(void)initRegistration;
 {
     NSString * registrationToken = [[FIRInstanceID instanceID] token];
-
+    
     if (registrationToken != nil) {
         NSLog(@"FCM Registration Token: %@", registrationToken);
         [self setFcmRegistrationToken: registrationToken];
-
+        
         id topics = [self fcmTopics];
         if (topics != nil) {
             for (NSString *topic in topics) {
@@ -67,12 +68,12 @@
                 [pubSub subscribeToTopic:topic];
             }
         }
-
+        
         [self registerWithToken:registrationToken];
     } else {
         NSLog(@"FCM token is null");
     }
-
+    
 }
 
 //  FCM refresh token
@@ -112,7 +113,7 @@
 - (void)unregister:(CDVInvokedUrlCommand*)command;
 {
     NSArray* topics = [command argumentAtIndex:0];
-
+    
     if (topics != nil) {
         id pubSub = [FIRMessaging messaging];
         for (NSString *topic in topics) {
@@ -144,7 +145,7 @@
 - (void)unsubscribe:(CDVInvokedUrlCommand*)command;
 {
     NSString* topic = [command argumentAtIndex:0];
-
+    
     if (topic != nil) {
         NSLog(@"unsubscribe from topic: %@", topic);
         id pubSub = [FIRMessaging messaging];
@@ -165,9 +166,9 @@
     if (([voipArg isKindOfClass:[NSString class]] && [voipArg isEqualToString:@"true"]) || [voipArg boolValue]) {
         [self.commandDelegate runInBackground:^ {
             NSLog(@"Push Plugin VoIP set to true");
-
+            
             self.callbackId = command.callbackId;
-
+            
             PKPushRegistry *pushRegistry = [[PKPushRegistry alloc] initWithQueue:dispatch_get_main_queue()];
             pushRegistry.delegate = self;
             pushRegistry.desiredPushTypes = [NSSet setWithObject:PKPushTypeVoIP];
@@ -177,131 +178,236 @@
         [[NSNotificationCenter defaultCenter]
          addObserver:self selector:@selector(onTokenRefresh)
          name:kFIRInstanceIDTokenRefreshNotification object:nil];
-
+        
         [[NSNotificationCenter defaultCenter]
          addObserver:self selector:@selector(sendDataMessageFailure:)
          name:FIRMessagingSendErrorNotification object:nil];
-
+        
         [[NSNotificationCenter defaultCenter]
          addObserver:self selector:@selector(sendDataMessageSuccess:)
          name:FIRMessagingSendSuccessNotification object:nil];
-
+        
         [[NSNotificationCenter defaultCenter]
          addObserver:self selector:@selector(didDeleteMessagesOnServer)
          name:FIRMessagingMessagesDeletedNotification object:nil];
-
+        
         [self.commandDelegate runInBackground:^ {
             NSLog(@"Push Plugin register called");
             self.callbackId = command.callbackId;
-
+            
             NSArray* topics = [iosOptions objectForKey:@"topics"];
             [self setFcmTopics:topics];
-
-            UNAuthorizationOptions authorizationOptions = UNAuthorizationOptionNone;
-
+            
             id badgeArg = [iosOptions objectForKey:@"badge"];
             id soundArg = [iosOptions objectForKey:@"sound"];
             id alertArg = [iosOptions objectForKey:@"alert"];
             id clearBadgeArg = [iosOptions objectForKey:@"clearBadge"];
-
-            if (([badgeArg isKindOfClass:[NSString class]] && [badgeArg isEqualToString:@"true"]) || [badgeArg boolValue])
-            {
-                authorizationOptions |= UNAuthorizationOptionBadge;
-            }
-
-            if (([soundArg isKindOfClass:[NSString class]] && [soundArg isEqualToString:@"true"]) || [soundArg boolValue])
-            {
-                authorizationOptions |= UNAuthorizationOptionSound;
-            }
-
-            if (([alertArg isKindOfClass:[NSString class]] && [alertArg isEqualToString:@"true"]) || [alertArg boolValue])
-            {
-                authorizationOptions |= UNAuthorizationOptionAlert;
-            }
-
-            if (clearBadgeArg == nil || ([clearBadgeArg isKindOfClass:[NSString class]] && [clearBadgeArg isEqualToString:@"false"]) || ![clearBadgeArg boolValue]) {
-                NSLog(@"PushPlugin.register: setting badge to false");
-                clearBadge = NO;
-            } else {
-                NSLog(@"PushPlugin.register: setting badge to true");
-                clearBadge = YES;
-                [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
-            }
-            NSLog(@"PushPlugin.register: clear badge is set to %d", clearBadge);
-
+            id criticalAlert = [iosOptions objectForKey:@"criticalAlert"];
+            
             isInline = NO;
-
-            NSLog(@"PushPlugin.register: better button setup");
-            // setup action buttons
-            NSMutableSet<UNNotificationCategory *> *categories = [[NSMutableSet alloc] init];
-            id categoryOptions = [iosOptions objectForKey:@"categories"];
-            if (categoryOptions != nil && [categoryOptions isKindOfClass:[NSDictionary class]]) {
-                for (id key in categoryOptions) {
-                    NSLog(@"categories: key %@", key);
-                    id category = [categoryOptions objectForKey:key];
-
-                    id yesButton = [category objectForKey:@"yes"];
-                    UNNotificationAction *yesAction;
-                    if (yesButton != nil && [yesButton  isKindOfClass:[NSDictionary class]]) {
-                        yesAction = [self createAction: yesButton];
-                    }
-                    id noButton = [category objectForKey:@"no"];
-                    UNNotificationAction *noAction;
-                    if (noButton != nil && [noButton  isKindOfClass:[NSDictionary class]]) {
-                        noAction = [self createAction: noButton];
-                    }
-                    id maybeButton = [category objectForKey:@"maybe"];
-                    UNNotificationAction *maybeAction;
-                    if (maybeButton != nil && [maybeButton  isKindOfClass:[NSDictionary class]]) {
-                        maybeAction = [self createAction: maybeButton];
-                    }
-
-                    // Identifier to include in your push payload and local notification
-                    NSString *identifier = key;
-
-                    NSMutableArray<UNNotificationAction *> *actions = [[NSMutableArray alloc] init];
-                    if (yesButton != nil) {
-                        [actions addObject:yesAction];
-                    }
-                    if (noButton != nil) {
-                        [actions addObject:noAction];
-                    }
-                    if (maybeButton != nil) {
-                        [actions addObject:maybeAction];
-                    }
-
-                    UNNotificationCategory *notificationCategory = [UNNotificationCategory categoryWithIdentifier:identifier
-                                                                                                          actions:actions
-                                                                                                intentIdentifiers:@[]
-                                                                                                          options:UNNotificationCategoryOptionNone];
-
-                    NSLog(@"Adding category %@", key);
-                    [categories addObject:notificationCategory];
+            
+            if (@available(iOS 10.0, *)) {               
+                if (clearBadgeArg == nil || ([clearBadgeArg isKindOfClass:[NSString class]] && [clearBadgeArg isEqualToString:@"false"]) || ![clearBadgeArg boolValue]) {
+                    NSLog(@"PushPlugin.register: setting badge to false");
+                    clearBadge = NO;
+                } else {
+                    NSLog(@"PushPlugin.register: setting badge to true");
+                    clearBadge = YES;
+                    [[UNUserNotificationCenter currentNotificationCenter] setValue:[NSNumber numberWithInt:0] forKey:@"badge"];
                 }
-
+                NSLog(@"PushPlugin.register: clear badge is set to %d", clearBadge);
+                
+                UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+                UNAuthorizationOptions UserAuthorizationOptions = UNAuthorizationOptionNone;
+                
+                if (([badgeArg isKindOfClass:[NSString class]] && [badgeArg isEqualToString:@"true"]) || [badgeArg boolValue]) {
+                    UserAuthorizationOptions |= UNAuthorizationOptionBadge;
+                }
+                
+                if (([soundArg isKindOfClass:[NSString class]] && [soundArg isEqualToString:@"true"]) || [soundArg boolValue]) {
+                    UserAuthorizationOptions |= UNAuthorizationOptionSound;
+                }
+                
+                if (([alertArg isKindOfClass:[NSString class]] && [alertArg isEqualToString:@"true"]) || [alertArg boolValue]) {
+                    UserAuthorizationOptions |= UNAuthorizationOptionAlert;
+                }
+                
+                if (([criticalAlert isKindOfClass:[NSString class]] && [criticalAlert isEqualToString:@"true"]) || [criticalAlert boolValue]){
+                    if (@available(iOS 12.0, *)){
+                        UserAuthorizationOptions |= UNAuthorizationOptionCriticalAlert;
+                    }
+                }
+                
+                NSLog(@"PushPlugin.register: better button setup");
+                // setup action buttons
+                NSMutableSet *categories = [[NSMutableSet alloc] init];
+                id categoryOptions = [iosOptions objectForKey:@"categories"];
+                if (categoryOptions != nil && [categoryOptions isKindOfClass:[NSDictionary class]]) {
+                    for (id key in categoryOptions) {
+                        NSLog(@"categories: key %@", key);
+                        id category = [categoryOptions objectForKey:key];
+                        
+                        id yesButton = [category objectForKey:@"yes"];
+                        UNNotificationAction *yesAction;
+                        if (yesButton != nil && [yesButton  isKindOfClass:[NSDictionary class]]) {
+                            yesAction = [self UNCreateAction: yesButton];
+                        }
+                        
+                        id noButton = [category objectForKey:@"no"];
+                        UNNotificationAction *noAction;
+                        if (noButton != nil && [noButton  isKindOfClass:[NSDictionary class]]) {
+                            noAction = [self UNCreateAction: noButton];
+                        }
+                        
+                        id maybeButton = [category objectForKey:@"maybe"];
+                        UNNotificationAction *maybeAction;
+                        if (maybeButton != nil && [maybeButton  isKindOfClass:[NSDictionary class]]) {
+                            maybeAction = [self UNCreateAction: maybeButton];
+                        }
+                        
+                        NSMutableArray *categoryArray = [[NSMutableArray alloc] init];
+                        NSMutableArray *minimalCategoryArray = [[NSMutableArray alloc] init];
+                        if (yesButton != nil) {
+                            [categoryArray addObject:yesAction];
+                            [minimalCategoryArray addObject:yesAction];
+                        }
+                        if (noButton != nil) {
+                            [categoryArray addObject:noAction];
+                            [minimalCategoryArray addObject:noAction];
+                        }
+                        if (maybeButton != nil) {
+                            [categoryArray addObject:maybeAction];
+                        }
+                        
+                        // intentIdentifiers - to check
+                        UNNotificationCategory *notificationCategory = [UNNotificationCategory categoryWithIdentifier:key actions:categoryArray intentIdentifiers:minimalCategoryArray options:UNNotificationCategoryOptionNone];
+                        
+                        NSLog(@"Adding category %@", key);
+                        [categories addObject:notificationCategory];
+                        
+                    }
+                }
+                [center requestAuthorizationWithOptions:UserAuthorizationOptions
+                                      completionHandler:^(BOOL granted, NSError * _Nullable error) {
+                                          if (granted){
+                                              NSLog(@"Access granted");
+                                              dispatch_async(dispatch_get_main_queue(), ^{
+                                                  [center setNotificationCategories:categories];
+                                                  [[UIApplication sharedApplication] registerForRemoteNotifications];
+                                              });
+                                          }
+                                          else {
+                                              NSLog(@"Access denied");
+                                          }
+                                      }];
             }
-
-            UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-            [center setNotificationCategories:categories];
-            [self handleNotificationSettingsWithAuthorizationOptions:[NSNumber numberWithInteger:authorizationOptions]];
-
-            [[NSNotificationCenter defaultCenter] addObserver:self
-                                                     selector:@selector(handleNotificationSettings:)
-                                                         name:pushPluginApplicationDidBecomeActiveNotification
-                                                       object:nil];
-
-
-
+            else {               
+                if (clearBadgeArg == nil || ([clearBadgeArg isKindOfClass:[NSString class]] && [clearBadgeArg isEqualToString:@"false"]) || ![clearBadgeArg boolValue]) {
+                    NSLog(@"PushPlugin.register: setting badge to false");
+                    clearBadge = NO;
+                } else {
+                    NSLog(@"PushPlugin.register: setting badge to true");
+                    clearBadge = YES;
+                    [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
+                }
+                NSLog(@"PushPlugin.register: clear badge is set to %d", clearBadge);
+                
+                UIUserNotificationType UserNotificationTypes = UIUserNotificationTypeNone;
+            
+                
+                if (([badgeArg isKindOfClass:[NSString class]] && [badgeArg isEqualToString:@"true"]) || [badgeArg boolValue])
+                {
+                    UserNotificationTypes |= UIUserNotificationTypeBadge;
+                }
+                
+                if (([soundArg isKindOfClass:[NSString class]] && [soundArg isEqualToString:@"true"]) || [soundArg boolValue])
+                {
+                    UserNotificationTypes |= UIUserNotificationTypeSound;
+                }
+                
+                if (([alertArg isKindOfClass:[NSString class]] && [alertArg isEqualToString:@"true"]) || [alertArg boolValue])
+                {
+                    UserNotificationTypes |= UIUserNotificationTypeAlert;
+                }
+                
+                UserNotificationTypes |= UIUserNotificationActivationModeBackground;
+                
+                NSLog(@"PushPlugin.register: better button setup");
+                // setup action buttons
+                NSMutableSet *categories = [[NSMutableSet alloc] init];
+                id categoryOptions = [iosOptions objectForKey:@"categories"];
+                if (categoryOptions != nil && [categoryOptions isKindOfClass:[NSDictionary class]]) {
+                    for (id key in categoryOptions) {
+                        NSLog(@"categories: key %@", key);
+                        id category = [categoryOptions objectForKey:key];
+                        
+                        id yesButton = [category objectForKey:@"yes"];
+                        UIMutableUserNotificationAction *yesAction;
+                        if (yesButton != nil && [yesButton  isKindOfClass:[NSDictionary class]]) {
+                            yesAction = [self createAction: yesButton];
+                        }
+                        id noButton = [category objectForKey:@"no"];
+                        UIMutableUserNotificationAction *noAction;
+                        if (noButton != nil && [noButton  isKindOfClass:[NSDictionary class]]) {
+                            noAction = [self createAction: noButton];
+                        }
+                        id maybeButton = [category objectForKey:@"maybe"];
+                        UIMutableUserNotificationAction *maybeAction;
+                        if (maybeButton != nil && [maybeButton  isKindOfClass:[NSDictionary class]]) {
+                            maybeAction = [self createAction: maybeButton];
+                        }
+                        
+                        // First create the category
+                        UIMutableUserNotificationCategory *notificationCategory = [[UIMutableUserNotificationCategory alloc] init];
+                        
+                        // Identifier to include in your push payload and local notification
+                        notificationCategory.identifier = key;
+                        
+                        NSMutableArray *categoryArray = [[NSMutableArray alloc] init];
+                        NSMutableArray *minimalCategoryArray = [[NSMutableArray alloc] init];
+                        if (yesButton != nil) {
+                            [categoryArray addObject:yesAction];
+                            [minimalCategoryArray addObject:yesAction];
+                        }
+                        if (noButton != nil) {
+                            [categoryArray addObject:noAction];
+                            [minimalCategoryArray addObject:noAction];
+                        }
+                        if (maybeButton != nil) {
+                            [categoryArray addObject:maybeAction];
+                        }
+                        
+                        // Add the actions to the category and set the action context
+                        [notificationCategory setActions:categoryArray forContext:UIUserNotificationActionContextDefault];
+                        
+                        // Set the actions to present in a minimal context
+                        [notificationCategory setActions:minimalCategoryArray forContext:UIUserNotificationActionContextMinimal];
+                        
+                        NSLog(@"Adding category %@", key);
+                        [categories addObject:notificationCategory];
+                    }
+                    
+                }
+                
+                if ([[UIApplication sharedApplication]respondsToSelector:@selector(registerUserNotificationSettings:)]) {
+                    UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:UserNotificationTypes categories:categories];
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
+                        [[UIApplication sharedApplication] registerForRemoteNotifications];
+                    });
+                }
+            }
+            
             // Read GoogleService-Info.plist
             NSString *path = [[NSBundle mainBundle] pathForResource:@"GoogleService-Info" ofType:@"plist"];
-
+            
             // Load the file content and read the data into arrays
             NSDictionary *dict = [[NSDictionary alloc] initWithContentsOfFile:path];
             fcmSenderId = [dict objectForKey:@"GCM_SENDER_ID"];
             BOOL isGcmEnabled = [[dict valueForKey:@"IS_GCM_ENABLED"] boolValue];
-
+            
             NSLog(@"FCM Sender ID %@", fcmSenderId);
-
+            
             //  GCM options
             [self setFcmSenderId: fcmSenderId];
             if(isGcmEnabled && [[self fcmSenderId] length] > 0) {
@@ -317,7 +423,7 @@
                 [self setUsesFCM:NO];
             }
             id fcmSandboxArg = [iosOptions objectForKey:@"fcmSandbox"];
-
+            
             [self setFcmSandbox:@NO];
             if ([self usesFCM] &&
                 (([fcmSandboxArg isKindOfClass:[NSString class]] && [fcmSandboxArg isEqualToString:@"true"]) ||
@@ -326,33 +432,59 @@
                 NSLog(@"Using FCM Sandbox");
                 [self setFcmSandbox:@YES];
             }
-
+            
             if (notificationMessage) {            // if there is a pending startup notification
                 dispatch_async(dispatch_get_main_queue(), ^{
                     // delay to allow JS event handlers to be setup
                     [self performSelector:@selector(notificationReceived) withObject:nil afterDelay: 0.5];
                 });
             }
-
         }];
     }
 }
 
-- (UNNotificationAction *)createAction:(NSDictionary *)dictionary {
-    NSString *identifier = [dictionary objectForKey:@"callback"];
-    NSString *title = [dictionary objectForKey:@"title"];
+- (UNNotificationAction *)UNCreateAction:(NSDictionary *)dictionary {
+    const id identifier = [dictionary objectForKey:@"callback"];
+    const id title = [dictionary objectForKey:@"title"];
+    const id mode =[dictionary objectForKey:@"foreground"];
+    const id destructive = [dictionary objectForKey:@"destructive"];
+    
     UNNotificationActionOptions options = UNNotificationActionOptionNone;
-
-    id mode = [dictionary objectForKey:@"foreground"];
-    if (mode != nil && (([mode isKindOfClass:[NSString class]] && [mode isEqualToString:@"true"]) || [mode boolValue])) {
+    //options |= UNNotificationActionOptionAuthenticationRequired;
+    
+    if (mode != nil || (![mode isKindOfClass:[NSString class]] && ![mode isEqualToString:@"false"]) || [mode boolValue]) {
         options |= UNNotificationActionOptionForeground;
     }
-    id destructive = [dictionary objectForKey:@"destructive"];
-    if (destructive != nil && (([destructive isKindOfClass:[NSString class]] && [destructive isEqualToString:@"true"]) || [destructive boolValue])) {
+    
+    if (destructive != nil || (![destructive isKindOfClass:[NSString class]] && ![destructive isEqualToString:@"false"]) || [destructive boolValue]) {
         options |= UNNotificationActionOptionDestructive;
     }
-
+    
     return [UNNotificationAction actionWithIdentifier:identifier title:title options:options];
+}
+
+- (UIMutableUserNotificationAction *)createAction:(NSDictionary *)dictionary {
+    
+    UIMutableUserNotificationAction *myAction = [[UIMutableUserNotificationAction alloc] init];
+    
+    myAction = [[UIMutableUserNotificationAction alloc] init];
+    myAction.identifier = [dictionary objectForKey:@"callback"];
+    myAction.title = [dictionary objectForKey:@"title"];
+    id mode =[dictionary objectForKey:@"foreground"];
+    if (mode == nil || ([mode isKindOfClass:[NSString class]] && [mode isEqualToString:@"false"]) || ![mode boolValue]) {
+        myAction.activationMode = UIUserNotificationActivationModeBackground;
+    } else {
+        myAction.activationMode = UIUserNotificationActivationModeForeground;
+    }
+    id destructive = [dictionary objectForKey:@"destructive"];
+    if (destructive == nil || ([destructive isKindOfClass:[NSString class]] && [destructive isEqualToString:@"false"]) || ![destructive boolValue]) {
+        myAction.destructive = NO;
+    } else {
+        myAction.destructive = YES;
+    }
+    myAction.authenticationRequired = NO;
+    
+    return myAction;
 }
 
 - (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
@@ -361,24 +493,86 @@
         return;
     }
     NSLog(@"Push Plugin register success: %@", deviceToken);
-
+    
+    NSMutableDictionary *results = [NSMutableDictionary dictionary];
     NSString *token = [[[[deviceToken description] stringByReplacingOccurrencesOfString:@"<"withString:@""]
                         stringByReplacingOccurrencesOfString:@">" withString:@""]
                        stringByReplacingOccurrencesOfString: @" " withString: @""];
+    [results setValue:token forKey:@"deviceToken"];
+    
 #if !TARGET_IPHONE_SIMULATOR
+    // Get Bundle Info for Remote Registration (handy if you have more than one app)
+    [results setValue:[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleDisplayName"] forKey:@"appName"];
+    [results setValue:[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"] forKey:@"appVersion"];
+    
+    if (@available(iOS 10.0, *)) {
+        [[UNUserNotificationCenter currentNotificationCenter] getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
+    
+            // Set the defaults to disabled unless we find otherwise...
+            NSString *pushBadge = @"disabled";
+            NSString *pushAlert = @"disabled";
+            NSString *pushSound = @"disabled";
+            NSString *pushCriticalAlert = @"disabled";
+            
+            if(settings.badgeSetting){
+                pushBadge = @"enabled";
+            }
+            if(settings.alertSetting) {
+                pushAlert = @"enabled";
+            }
+            if(settings.soundSetting) {
+                pushSound = @"enabled";
+            }
+            if(@available(iOS 12.0, *)){
+                if (settings.criticalAlertSetting){
+                    pushCriticalAlert = @"enabled";
+                }
+            }
 
-    // Check what Notifications the user has turned on.  We registered for all three, but they may have manually disabled some or all of them.
-
-    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-    __weak PushPlugin *weakSelf = self;
-    [center getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
-
-        if(![weakSelf usesFCM]) {
-            [weakSelf registerWithToken: token];
+            [results setValue:pushBadge forKey:@"pushBadge"];
+            [results setValue:pushAlert forKey:@"pushAlert"];
+            [results setValue:pushSound forKey:@"pushSound"];
+            [results setValue:pushCriticalAlert forKey:@"pushCriticalAlert"];
+        }];
+    }
+    else {
+        // Set the defaults to disabled unless we find otherwise...
+        NSString *pushBadge = @"disabled";
+        NSString *pushAlert = @"disabled";
+        NSString *pushSound = @"disabled";
+        NSString *pushCriticalAlert = @"disabled";
+        
+        // Check what Notifications the user has turned on.  We registered for all three, but they may have manually disabled some or all of them.
+        NSUInteger rntypes = [[[UIApplication sharedApplication] currentUserNotificationSettings] types];
+        
+        // Check what Registered Types are turned on. This is a bit tricky since if two are enabled, and one is off, it will return a number 2... not telling you which
+        // one is actually disabled. So we are literally checking to see if rnTypes matches what is turned on, instead of by number. The "tricky" part is that the
+        // single notification types will only match if they are the ONLY one enabled.  Likewise, when we are checking for a pair of notifications, it will only be
+        // true if those two notifications are on.  This is why the code is written this way
+        if(rntypes & UIUserNotificationTypeBadge){
+            pushBadge = @"enabled";
         }
-    }];
-
-
+        if(rntypes & UIUserNotificationTypeAlert) {
+            pushAlert = @"enabled";
+        }
+        if(rntypes & UIUserNotificationTypeSound) {
+            pushSound = @"enabled";
+        }
+        
+        [results setValue:pushBadge forKey:@"pushBadge"];
+        [results setValue:pushAlert forKey:@"pushAlert"];
+        [results setValue:pushSound forKey:@"pushSound"];
+        [results setValue:pushCriticalAlert forKey:@"pushCriticalAlert"];
+    }
+    // Get the users Device Model, Display Name, Token & Version Number
+    UIDevice *dev = [UIDevice currentDevice];
+    [results setValue:dev.name forKey:@"deviceName"];
+    [results setValue:dev.model forKey:@"deviceModel"];
+    [results setValue:dev.systemVersion forKey:@"deviceSystemVersion"];
+    
+    if(![self usesFCM]) {
+        [self registerWithToken: token];
+    }
 #endif
 }
 
@@ -394,21 +588,21 @@
 
 - (void)notificationReceived {
     NSLog(@"Notification received");
-
+    
     if (notificationMessage && self.callbackId != nil)
     {
         NSMutableDictionary* message = [NSMutableDictionary dictionaryWithCapacity:4];
         NSMutableDictionary* additionalData = [NSMutableDictionary dictionaryWithCapacity:4];
-
-
+        
+        
         for (id key in notificationMessage) {
             if ([key isEqualToString:@"aps"]) {
                 id aps = [notificationMessage objectForKey:@"aps"];
-
+                
                 for(id key in aps) {
                     NSLog(@"Push Plugin key: %@", key);
                     id value = [aps objectForKey:key];
-
+                    
                     if ([key isEqualToString:@"alert"]) {
                         if ([value isKindOfClass:[NSDictionary class]]) {
                             for (id messageKey in value) {
@@ -441,60 +635,43 @@
                 [additionalData setObject:[notificationMessage objectForKey:key] forKey:key];
             }
         }
-
+        
         if (isInline) {
             [additionalData setObject:[NSNumber numberWithBool:YES] forKey:@"foreground"];
         } else {
             [additionalData setObject:[NSNumber numberWithBool:NO] forKey:@"foreground"];
         }
-
+        
         if (coldstart) {
             [additionalData setObject:[NSNumber numberWithBool:YES] forKey:@"coldstart"];
         } else {
             [additionalData setObject:[NSNumber numberWithBool:NO] forKey:@"coldstart"];
         }
-
+        
         [message setObject:additionalData forKey:@"additionalData"];
-
+        
         // send notification message
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:message];
         [pluginResult setKeepCallbackAsBool:YES];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
-
+        
         self.coldstart = NO;
         self.notificationMessage = nil;
     }
-}
-
-- (void)clearNotification:(CDVInvokedUrlCommand *)command
-{
-    NSNumber *notId = [command.arguments objectAtIndex:0];
-    [[UNUserNotificationCenter currentNotificationCenter] getDeliveredNotificationsWithCompletionHandler:^(NSArray<UNNotification *> * _Nonnull notifications) {
-        /*
-         * If the server generates a unique "notId" for every push notification, there should only be one match in these arrays, but if not, it will delete
-         * all notifications with the same value for "notId"
-         */
-        NSPredicate *matchingNotificationPredicate = [NSPredicate predicateWithFormat:@"request.content.userInfo.notId == %@", notId];
-        NSArray<UNNotification *> *matchingNotifications = [notifications filteredArrayUsingPredicate:matchingNotificationPredicate];
-        NSMutableArray<NSString *> *matchingNotificationIdentifiers = [NSMutableArray array];
-        for (UNNotification *notification in matchingNotifications) {
-            [matchingNotificationIdentifiers addObject:notification.request.identifier];
-        }
-        [[UNUserNotificationCenter currentNotificationCenter] removeDeliveredNotificationsWithIdentifiers:matchingNotificationIdentifiers];
-        
-        NSString *message = [NSString stringWithFormat:@"Cleared notification with ID: %@", notId];
-        CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:message];
-        [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
-    }];
 }
 
 - (void)setApplicationIconBadgeNumber:(CDVInvokedUrlCommand *)command
 {
     NSMutableDictionary* options = [command.arguments objectAtIndex:0];
     int badge = [[options objectForKey:@"badge"] intValue] ?: 0;
-
-    [[UIApplication sharedApplication] setApplicationIconBadgeNumber:badge];
-
+    
+    if (@available(iOS 10.0, *)) {
+        [[UNUserNotificationCenter currentNotificationCenter] setValue:[NSNumber numberWithInt:badge] forKey:@"badge"];
+    }
+    else {
+        [[UIApplication sharedApplication] setApplicationIconBadgeNumber:badge];
+    }
+    
     NSString* message = [NSString stringWithFormat:@"app badge count set to %d", badge];
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:message];
     [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
@@ -502,16 +679,29 @@
 
 - (void)getApplicationIconBadgeNumber:(CDVInvokedUrlCommand *)command
 {
-    NSInteger badge = [UIApplication sharedApplication].applicationIconBadgeNumber;
-
+    __block NSInteger badge;
+    if(@available(iOS 10.0, *)) {
+        [[UNUserNotificationCenter currentNotificationCenter] getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
+            badge = settings.badgeSetting;
+        }];
+    }
+    else {
+        badge = [UIApplication sharedApplication].applicationIconBadgeNumber;
+    }
+    
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsInt:(int)badge];
     [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
 }
 
 - (void)clearAllNotifications:(CDVInvokedUrlCommand *)command
 {
-    [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
-
+    if (@available(iOS 10.0, *)){
+        [[UNUserNotificationCenter currentNotificationCenter] setValue:[NSNumber numberWithInt:0] forKey:@"badge"];
+    }
+    else {
+        [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
+    }
+    
     NSString* message = [NSString stringWithFormat:@"cleared all notifications"];
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:message];
     [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
@@ -519,15 +709,25 @@
 
 - (void)hasPermission:(CDVInvokedUrlCommand *)command
 {
-    id<UIApplicationDelegate> appDelegate = [UIApplication sharedApplication].delegate;
-    if ([appDelegate respondsToSelector:@selector(checkUserHasRemoteNotificationsEnabledWithCompletionHandler:)]) {
-        [appDelegate performSelector:@selector(checkUserHasRemoteNotificationsEnabledWithCompletionHandler:) withObject:^(BOOL isEnabled) {
-            NSMutableDictionary* message = [NSMutableDictionary dictionaryWithCapacity:1];
-            [message setObject:[NSNumber numberWithBool:isEnabled] forKey:@"isEnabled"];
-            CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:message];
-            [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
-        }];
+    BOOL enabled = NO;
+    if (@available(iOS 10.0, *)){
+        id<UNUserNotificationCenterDelegate> delegate = [UNUserNotificationCenter currentNotificationCenter].delegate;
+        if([delegate respondsToSelector:@selector(hasPermission:)]){
+            enabled = [delegate respondsToSelector:@selector(hasPermission:)];
+        }
     }
+    else {
+        id<UIApplicationDelegate> appDelegate = [UIApplication sharedApplication].delegate;
+        if ([appDelegate respondsToSelector:@selector(userHasRemoteNotificationsEnabled)]) {
+            enabled = [appDelegate performSelector:@selector(userHasRemoteNotificationsEnabled)];
+        }
+    }
+
+    
+    NSMutableDictionary* message = [NSMutableDictionary dictionaryWithCapacity:1];
+    [message setObject:[NSNumber numberWithBool:enabled] forKey:@"isEnabled"];
+    CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:message];
+    [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
 }
 
 -(void)successWithMessage:(NSString *)myCallbackId withMsg:(NSString *)message
@@ -558,17 +758,17 @@
 {
     NSString        *errorMessage = (error) ? [NSString stringWithFormat:@"%@ - %@", message, [error localizedDescription]] : message;
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:errorMessage];
-
+    
     [self.commandDelegate sendPluginResult:commandResult callbackId:myCallbackId];
 }
 
 -(void) finish:(CDVInvokedUrlCommand*)command
 {
     NSLog(@"Push Plugin finish called");
-
+    
     [self.commandDelegate runInBackground:^ {
         NSString* notId = [command.arguments objectAtIndex:0];
-
+        
         dispatch_async(dispatch_get_main_queue(), ^{
             [NSTimer scheduledTimerWithTimeInterval:0.1
                                              target:self
@@ -576,7 +776,7 @@
                                            userInfo:notId
                                             repeats:NO];
         });
-
+        
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
@@ -584,10 +784,10 @@
 
 -(void)stopBackgroundTask:(NSTimer*)timer
 {
-    UIApplication *app = [UIApplication sharedApplication];
-
     NSLog(@"Push Plugin stopBackgroundTask called");
-
+    
+    UIApplication *app = [UIApplication sharedApplication];
+    
     if (handlerObj) {
         NSLog(@"Push Plugin handlerObj");
         completionHandler = [handlerObj[[timer userInfo]] copy];
@@ -597,6 +797,7 @@
             completionHandler = nil;
         }
     }
+
 }
 
 
@@ -606,14 +807,14 @@
         NSLog(@"VoIPPush Plugin register error - No device token:");
         return;
     }
-
+    
     NSLog(@"VoIPPush Plugin register success");
     const unsigned *tokenBytes = [credentials.token bytes];
     NSString *sToken = [NSString stringWithFormat:@"%08x%08x%08x%08x%08x%08x%08x%08x",
                         ntohl(tokenBytes[0]), ntohl(tokenBytes[1]), ntohl(tokenBytes[2]),
                         ntohl(tokenBytes[3]), ntohl(tokenBytes[4]), ntohl(tokenBytes[5]),
                         ntohl(tokenBytes[6]), ntohl(tokenBytes[7])];
-
+    
     [self registerWithToken:sToken];
 }
 
@@ -622,50 +823,6 @@
     NSLog(@"VoIP Notification received");
     self.notificationMessage = payload.dictionaryPayload;
     [self notificationReceived];
-}
-
-- (void)handleNotificationSettings:(NSNotification *)notification
-{
-    [self handleNotificationSettingsWithAuthorizationOptions:nil];
-}
-
-- (void)handleNotificationSettingsWithAuthorizationOptions:(NSNumber *)authorizationOptionsObject
-{
-    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-    UNAuthorizationOptions authorizationOptions = [authorizationOptionsObject unsignedIntegerValue];
-
-    __weak UNUserNotificationCenter *weakCenter = center;
-    [center getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
-
-        switch (settings.authorizationStatus) {
-            case UNAuthorizationStatusNotDetermined:
-            {
-                [weakCenter requestAuthorizationWithOptions:authorizationOptions completionHandler:^(BOOL granted, NSError * _Nullable error) {
-                    if (granted) {
-                        [self performSelectorOnMainThread:@selector(registerForRemoteNotifications)
-                                               withObject:nil
-                                            waitUntilDone:NO];
-                    }
-                }];
-                break;
-            }
-            case UNAuthorizationStatusAuthorized:
-            {
-                [self performSelectorOnMainThread:@selector(registerForRemoteNotifications)
-                                       withObject:nil
-                                    waitUntilDone:NO];
-                break;
-            }
-            case UNAuthorizationStatusDenied:
-            default:
-                break;
-        }
-    }];
-}
-
-- (void)registerForRemoteNotifications
-{
-    [[UIApplication sharedApplication] registerForRemoteNotifications];
 }
 
 @end

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -228,6 +228,10 @@ declare namespace PhonegapPluginPush {
 			 * If the array contains one or more strings each string will be used to subscribe to a FcmPubSub topic. Defaults to [].
 			 */
 			topics?: string[]
+			/**
+			 * If true|"true" the criticalAlerts will be available
+			 */
+			criticalAlert?: boolean | string
 		}
 
 		/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use UNUserNotification for iOS 10 and above.
For iOS 12 and above add support for critical notifications.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue [#2676](https://github.com/phonegap/phonegap-plugin-push/issues/2676)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It allows the iOS users to receive critical alerts.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with iPhones 5s, 7, iOS 9-12.3.1, ionic 5.2.1, cordova 9.0
#### You have to get proper entitlements from apple and configure the project in order to use the critical alerts.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] My code follows the code style of this project.
- [ X ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X ] I have read the **CONTRIBUTING** document.
- [ X ] I have added tests to cover my changes.
- [ X ] All new and existing tests passed.
