### PR TITLE
Issue #2788: fixed breaking change of APNs deviceToken format for iOS 13

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -362,9 +362,16 @@
     }
     NSLog(@"Push Plugin register success: %@", deviceToken);
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
+    // [deviceToken description] is like "{length = 32, bytes = 0xd3d997af 967d1f43 b405374a 13394d2f ... 28f10282 14af515f }"
+    NSString *token = [self hexadecimalStringFromData:deviceToken];
+#else
+    // [deviceToken description] is like "<124686a5 556a72ca d808f572 00c323b9 3eff9285 92445590 3225757d b83967be>"
     NSString *token = [[[[deviceToken description] stringByReplacingOccurrencesOfString:@"<"withString:@""]
                         stringByReplacingOccurrencesOfString:@">" withString:@""]
                        stringByReplacingOccurrencesOfString: @" " withString: @""];
+#endif
+
 #if !TARGET_IPHONE_SIMULATOR
 
     // Check what Notifications the user has turned on.  We registered for all three, but they may have manually disabled some or all of them.
@@ -380,6 +387,21 @@
 
 
 #endif
+}
+
+- (NSString *)hexadecimalStringFromData:(NSData *)data
+{
+    NSUInteger dataLength = data.length;
+    if (dataLength == 0) {
+        return nil;
+    }
+
+    const unsigned char *dataBuffer = data.bytes;
+    NSMutableString *hexString  = [NSMutableString stringWithCapacity:(dataLength * 2)];
+    for (int i = 0; i < dataLength; ++i) {
+        [hexString appendFormat:@"%02x", dataBuffer[i]];
+    }
+    return [hexString copy];
 }
 
 - (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix parsing method for registered device token. On iOS 12 or lower, it will work as before. On iOS 13 or higher, new `hexadecimalStringFromData` method makes binary to hexadecimal string.

The following article was helpful:

* https://forums.developer.apple.com/thread/117545
* https://github.com/facebook/facebook-objc-sdk/blob/a9ede70/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.m#L521-L534

## Related Issue

* #2788 iOS token weird format

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Until iOS 12, the result of `[deviceToken description]` was like `"<124686a5 556a72ca d808f572 00c323b9 3eff9285 92445590 3225757d b83967be>"` , so we only had to remove the symbols and spaces.

However, on iOS 13, the result of `[deviceToken description]` becomes `"{length = 32, bytes = 0xd3d997af 967d1f43 b405374a 13394d2f ... 28f10282 14af515f}"` , and deviceToken cannot be extracted by the previous conversion. The *broken* token is provided as the data for `on('registration', callback)` .

With this fix, both formats can be handled.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

iPad 6Gen iOS@13.0.0
iPhone 8 iOS@12.4
Cordova@8.1.2
Cordova ios@5.0.0
Xcode@11.0 beta (11M336w)

On iOS13, following log shows hexadecimal string like `124686a5556a72cad808f57200c323b93eff9285924455903225757db83967be`.

```
push.on('registration', data => {
  console.log(data.registrationId);
});
```

And on iOS 12 works same.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
