### PR TITLE
chore: update dev dependencies

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    "es2015"
+    "@babel/preset-env"
   ],
   "plugins": [
     ["add-header-comment", {

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,17 +1,16 @@
 {
-  "extends": "airbnb",
+  "extends": "airbnb-base",
   "parser": "babel-eslint",
-  "ecmaFeatures": {
-    "experimentalObjectRestSpread": true
-  },
   "rules": {
     "spaced-comment": 0,
     "no-console": 0,
-    "no-unused-expressions": [2, { "allowShortCircuit": true }]
+    "no-unused-expressions": [2, { "allowShortCircuit": true }],
+    "class-methods-use-this": 0
   },
   "env": {
-      "node": true,
-      "mocha": true,
-      "browser": true
+    "browser": true
+  },
+  "globals": {
+    "cordova": false
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
-node_js:
-- '4'
+node_js: 8
 branches:
   only:
   - master

--- a/package.json
+++ b/package.json
@@ -69,27 +69,25 @@
   "scripts": {
     "build": "babel src/js --out-dir www",
     "build:watch": "nodemon -w ./src/js -e js -x npm run build",
-    "eslint": "node node_modules/.bin/eslint src/js",
-    "jasmine": "jasmine-node --color spec",
+    "eslint": "eslint src/js",
+    "jasmine": "jasmine --config=spec/unit.json",
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
-    "test": "npm run build && npm run jasmine"
+    "test": "npm run build && npm run eslint && npm run jasmine"
   },
   "devDependencies": {
-    "babel-cli": "^6.10.1",
-    "babel-core": "^6.10.4",
-    "babel-eslint": "^6.1.0",
-    "babel-preset-es2015": "^6.9.0",
-    "eslint": "^2.13.1",
-    "eslint-config-airbnb": "^9.0.1",
-    "eslint-plugin-import": "^1.9.2",
-    "eslint-plugin-jsx-a11y": "^1.5.3",
-    "eslint-plugin-react": "^5.2.2",
-    "jasmine-node": "1.14.5",
-    "nodemon": "^1.9.2",
+    "@babel/cli": "^7.5.5",
+    "@babel/core": "^7.5.5",
+    "@babel/preset-env": "^7.5.5",
+    "babel-eslint": "^10.0.3",
+    "babel-plugin-add-header-comment": "^1.0.3",
+    "eslint": "^6.2.2",
+    "eslint-config-airbnb-base": "^14.0.0",
+    "eslint-plugin-import": "^2.18.2",
+    "jasmine": "^3.4.0",
+    "nodemon": "^1.19.1",
     "pluginpub": "^0.0.9"
   },
   "dependencies": {
-    "babel-plugin-add-header-comment": "^1.0.3",
     "install": "^0.8.2"
   }
 }

--- a/spec/.eslintrc.yml
+++ b/spec/.eslintrc.yml
@@ -1,0 +1,2 @@
+env:
+  jasmine: true

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -4,102 +4,102 @@
  * Module dependencies.
  */
 
-var cordova = require('./helper/cordova'),
-  PushNotification = require('../www/push'),
-  execSpy,
-  execWin,
-  options;
+const cordova = require('./helper/cordova');
+const PushNotification = require('../www/push');
+let execSpy;
+let execWin;
+let options;
 
 /*!
  * Specification.
  */
 
-describe('phonegap-plugin-push', function () {
-  beforeEach(function () {
+describe('phonegap-plugin-push', () => {
+  beforeEach(() => {
     options = { android: {}, ios: {}, windows: {} };
     execWin = jasmine.createSpy();
-    execSpy = spyOn(cordova.required, 'cordova/exec').andCallFake(execWin);
+    execSpy = spyOn(cordova.required, 'cordova/exec').and.callFake(execWin);
   });
 
-  describe('PushNotification', function () {
-    it('should exist', function () {
+  describe('PushNotification', () => {
+    it('should exist', () => {
       expect(PushNotification).toBeDefined();
       expect(typeof PushNotification === 'object').toBe(true);
     });
 
-    it('should contain a init function', function () {
+    it('should contain a init function', () => {
       expect(PushNotification.init).toBeDefined();
       expect(typeof PushNotification.init === 'function').toBe(true);
     });
 
-    it('should contain a hasPermission function', function () {
+    it('should contain a hasPermission function', () => {
       expect(PushNotification.hasPermission).toBeDefined();
       expect(typeof PushNotification.hasPermission === 'function').toBe(true);
     });
 
-    it('should contain a createChannel function', function () {
+    it('should contain a createChannel function', () => {
       expect(PushNotification.createChannel).toBeDefined();
       expect(typeof PushNotification.createChannel === 'function').toBe(true);
     });
 
-    it('should contain a deleteChannel function', function () {
+    it('should contain a deleteChannel function', () => {
       expect(PushNotification.deleteChannel).toBeDefined();
       expect(typeof PushNotification.deleteChannel === 'function').toBe(true);
     });
 
-    it('should contain a listChannels function', function () {
+    it('should contain a listChannels function', () => {
       expect(PushNotification.listChannels).toBeDefined();
       expect(typeof PushNotification.listChannels === 'function').toBe(true);
     });
 
-    it('should contain a unregister function', function () {
-      var push = PushNotification.init({});
+    it('should contain a unregister function', () => {
+      const push = PushNotification.init({});
       expect(push.unregister).toBeDefined();
       expect(typeof push.unregister === 'function').toBe(true);
     });
 
-    it('should contain a getApplicationIconBadgeNumber function', function () {
-      var push = PushNotification.init({});
+    it('should contain a getApplicationIconBadgeNumber function', () => {
+      const push = PushNotification.init({});
       expect(push.getApplicationIconBadgeNumber).toBeDefined();
       expect(typeof push.getApplicationIconBadgeNumber === 'function').toBe(true);
     });
 
-    it('should contain a setApplicationIconBadgeNumber function', function () {
-      var push = PushNotification.init({});
+    it('should contain a setApplicationIconBadgeNumber function', () => {
+      const push = PushNotification.init({});
       expect(push.setApplicationIconBadgeNumber).toBeDefined();
       expect(typeof push.setApplicationIconBadgeNumber === 'function').toBe(true);
     });
 
-    it('should contain a clearAllNotifications function', function () {
-      var push = PushNotification.init({});
+    it('should contain a clearAllNotifications function', () => {
+      const push = PushNotification.init({});
       expect(push.clearAllNotifications).toBeDefined();
       expect(typeof push.clearAllNotifications === 'function').toBe(true);
     });
-    
-    it('should contain a clearNotification function', function () {
-      var push = PushNotification.init({});
+
+    it('should contain a clearNotification function', () => {
+      const push = PushNotification.init({});
       expect(push.clearNotification).toBeDefined();
       expect(typeof push.clearNotification === 'function').toBe(true);
     });
 
-    it('should contain a subscribe function', function () {
-      var push = PushNotification.init({});
+    it('should contain a subscribe function', () => {
+      const push = PushNotification.init({});
       expect(push.subscribe).toBeDefined();
       expect(typeof push.subscribe === 'function').toBe(true);
     });
 
-    it('should contain a unsubscribe function', function () {
-      var push = PushNotification.init({});
+    it('should contain a unsubscribe function', () => {
+      const push = PushNotification.init({});
       expect(push.unsubscribe).toBeDefined();
       expect(typeof push.unsubscribe === 'function').toBe(true);
     });
   });
 
-  describe('PushNotification instance', function () {
-    describe('cordova.exec', function () {
-      it('should call cordova.exec on next process tick', function (done) {
+  describe('PushNotification instance', () => {
+    describe('cordova.exec', () => {
+      it('should call cordova.exec on next process tick', (done) => {
         PushNotification.init(options);
-        setTimeout(function () {
+        setTimeout(() => {
           expect(execSpy).toHaveBeenCalledWith(
             jasmine.any(Function),
             jasmine.any(Function),
@@ -112,22 +112,22 @@ describe('phonegap-plugin-push', function () {
       });
     });
 
-    describe('on "registration" event', function () {
-      it('should be emitted with an argument', function (done) {
-        execSpy.andCallFake(function (win, fail, service, id, args) {
+    describe('on "registration" event', () => {
+      it('should be emitted with an argument', (done) => {
+        execSpy.and.callFake((win, fail, service, id, args) => {
           win({ registrationId: 1 });
         });
-        var push = PushNotification.init(options);
-        push.on('registration', function (data) {
+        const push = PushNotification.init(options);
+        push.on('registration', (data) => {
           expect(data.registrationId).toEqual(1);
           done();
         });
       });
     });
 
-    describe('on "notification" event', function () {
-      beforeEach(function () {
-        execSpy.andCallFake(function (win, fail, service, id, args) {
+    describe('on "notification" event', () => {
+      beforeEach(() => {
+        execSpy.and.callFake((win, fail, service, id, args) => {
           win({
             message: 'Message',
             title: 'Title',
@@ -139,69 +139,69 @@ describe('phonegap-plugin-push', function () {
         });
       });
 
-      it('should be emitted on success', function (done) {
-        var push = PushNotification.init(options);
-        push.on('notification', function (data) {
+      it('should be emitted on success', (done) => {
+        const push = PushNotification.init(options);
+        push.on('notification', (data) => {
           done();
         });
       });
 
-      it('should provide the data.message argument', function (done) {
-        var push = PushNotification.init(options);
-        push.on('notification', function (data) {
+      it('should provide the data.message argument', (done) => {
+        const push = PushNotification.init(options);
+        push.on('notification', (data) => {
           expect(data.message).toEqual('Message');
           done();
         });
       });
 
-      it('should provide the data.title argument', function (done) {
-        var push = PushNotification.init(options);
-        push.on('notification', function (data) {
+      it('should provide the data.title argument', (done) => {
+        const push = PushNotification.init(options);
+        push.on('notification', (data) => {
           expect(data.title).toEqual('Title');
           done();
         });
       });
 
-      it('should provide the data.count argument', function (done) {
-        var push = PushNotification.init(options);
-        push.on('notification', function (data) {
+      it('should provide the data.count argument', (done) => {
+        const push = PushNotification.init(options);
+        push.on('notification', (data) => {
           expect(data.count).toEqual(1);
           done();
         });
       });
 
-      it('should provide the data.sound argument', function (done) {
-        var push = PushNotification.init(options);
-        push.on('notification', function (data) {
+      it('should provide the data.sound argument', (done) => {
+        const push = PushNotification.init(options);
+        push.on('notification', (data) => {
           expect(data.sound).toEqual('beep');
           done();
         });
       });
 
-      it('should provide the data.image argument', function (done) {
-        var push = PushNotification.init(options);
-        push.on('notification', function (data) {
+      it('should provide the data.image argument', (done) => {
+        const push = PushNotification.init(options);
+        push.on('notification', (data) => {
           expect(data.image).toEqual('Image');
           done();
         });
       });
 
-      it('should provide the data.additionalData argument', function (done) {
-        var push = PushNotification.init(options);
-        push.on('notification', function (data) {
+      it('should provide the data.additionalData argument', (done) => {
+        const push = PushNotification.init(options);
+        push.on('notification', (data) => {
           expect(data.additionalData).toEqual({});
           done();
         });
       });
     });
 
-    describe('on "error" event', function () {
-      it('should be emitted with an Error', function (done) {
-        execSpy.andCallFake(function (win, fail, service, id, args) {
+    describe('on "error" event', () => {
+      it('should be emitted with an Error', (done) => {
+        execSpy.and.callFake((win, fail, service, id, args) => {
           fail('something went wrong');
         });
-        var push = PushNotification.init(options);
-        push.on('error', function (e) {
+        const push = PushNotification.init(options);
+        push.on('error', (e) => {
           expect(e).toEqual(jasmine.any(Error));
           expect(e.message).toEqual('something went wrong');
           done();
@@ -209,10 +209,10 @@ describe('phonegap-plugin-push', function () {
       });
     });
 
-    describe('off "notification" event', function () {
-      it('should exist and be registered a callback handle', function (done) {
-        var push = PushNotification.init(options),
-          eventHandler = function () {};
+    describe('off "notification" event', () => {
+      it('should exist and be registered a callback handle', (done) => {
+        const push = PushNotification.init(options),
+          eventHandler = () => {};
 
         push.on('notification', eventHandler);
 
@@ -223,10 +223,10 @@ describe('phonegap-plugin-push', function () {
       });
     });
 
-    describe('off "registration" event', function () {
-      it('should exist and be registered a callback handle', function (done) {
-        var push = PushNotification.init(options),
-          eventHandler = function () {};
+    describe('off "registration" event', () => {
+      it('should exist and be registered a callback handle', (done) => {
+        const push = PushNotification.init(options),
+          eventHandler = () => {};
 
         push.on('registration', eventHandler);
 
@@ -237,10 +237,10 @@ describe('phonegap-plugin-push', function () {
       });
     });
 
-    describe('off "error" event', function () {
-      it('should exist and be registered a callback handle', function (done) {
-        var push = PushNotification.init(options),
-          eventHandler = function () {};
+    describe('off "error" event', () => {
+      it('should exist and be registered a callback handle', (done) => {
+        const push = PushNotification.init(options),
+          eventHandler = () => {};
 
         push.on('error', eventHandler);
         push.off('error', eventHandler);
@@ -250,10 +250,10 @@ describe('phonegap-plugin-push', function () {
       });
     });
 
-    describe('unregister method', function () {
-      it('should clear "registration" event handlers', function (done) {
-        var push = PushNotification.init(options),
-          eventHandler = function () {};
+    describe('unregister method', () => {
+      it('should clear "registration" event handlers', (done) => {
+        const push = PushNotification.init(options);
+        const eventHandler = () => {};
 
         expect(push.handlers.registration.length).toEqual(0);
 
@@ -262,19 +262,19 @@ describe('phonegap-plugin-push', function () {
         expect(push.handlers.registration.length).toEqual(1);
         expect(push.handlers.registration.indexOf(eventHandler)).toBeGreaterThan(-1);
 
-        execSpy.andCallFake(function (win, fail, service, id, args) {
+        execSpy.and.callFake((win, fail, service, id, args) => {
           win();
         });
-        push.unregister(function () {
+        push.unregister(() => {
           expect(push.handlers.registration.length).toEqual(0);
           expect(push.handlers.registration.indexOf(eventHandler)).toEqual(-1);
           done();
         });
       });
 
-      it('should clear "notification" event handlers', function (done) {
-        var push = PushNotification.init(options),
-          eventHandler = function () {};
+      it('should clear "notification" event handlers', (done) => {
+        const push = PushNotification.init(options);
+        const eventHandler = () => {};
 
         expect(push.handlers.notification.length).toEqual(0);
 
@@ -283,19 +283,19 @@ describe('phonegap-plugin-push', function () {
         expect(push.handlers.notification.length).toEqual(1);
         expect(push.handlers.notification.indexOf(eventHandler)).toBeGreaterThan(-1);
 
-        execSpy.andCallFake(function (win, fail, service, id, args) {
+        execSpy.and.callFake((win, fail, service, id, args) => {
           win();
         });
-        push.unregister(function () {
+        push.unregister(() => {
           expect(push.handlers.notification.length).toEqual(0);
           expect(push.handlers.notification.indexOf(eventHandler)).toEqual(-1);
           done();
         });
       });
 
-      it('should clear "error" event handlers', function (done) {
-        var push = PushNotification.init(options),
-          eventHandler = function () {};
+      it('should clear "error" event handlers', (done) => {
+        const push = PushNotification.init(options);
+        const eventHandler = () => {};
 
         expect(push.handlers.error.length).toEqual(0);
 
@@ -304,10 +304,10 @@ describe('phonegap-plugin-push', function () {
         expect(push.handlers.error.length).toEqual(1);
         expect(push.handlers.error.indexOf(eventHandler)).toBeGreaterThan(-1);
 
-        execSpy.andCallFake(function (win, fail, service, id, args) {
+        execSpy.and.callFake((win, fail, service, id, args) => {
           win();
         });
-        push.unregister(function () {
+        push.unregister(() => {
           expect(push.handlers.error.length).toEqual(0);
           expect(push.handlers.error.indexOf(eventHandler)).toEqual(-1);
           done();
@@ -315,10 +315,10 @@ describe('phonegap-plugin-push', function () {
       });
     });
 
-    describe('unregister topics method', function () {
-      it('should not clear "registration" event handlers', function (done) {
-        var push = PushNotification.init(options),
-          eventHandler = function () {};
+    describe('unregister topics method', () => {
+      it('should not clear "registration" event handlers', (done) => {
+        const push = PushNotification.init(options);
+        const eventHandler = () => {};
 
         expect(push.handlers.registration.length).toEqual(0);
 
@@ -327,23 +327,23 @@ describe('phonegap-plugin-push', function () {
         expect(push.handlers.registration.length).toEqual(1);
         expect(push.handlers.registration.indexOf(eventHandler)).toBeGreaterThan(-1);
 
-        execSpy.andCallFake(function (win, fail, service, id, args) {
+        execSpy.and.callFake((win, fail, service, id, args) => {
           win();
         });
         push.unregister(
-          function () {
+          () => {
             expect(push.handlers.registration.length).toEqual(1);
             expect(push.handlers.registration.indexOf(eventHandler)).toBeGreaterThan(-1);
             done();
           },
-          function () {},
+          () => {},
           ['foo', 'bar']
         );
       });
 
-      it('should not clear "notification" event handlers', function (done) {
-        var push = PushNotification.init(options),
-          eventHandler = function () {};
+      it('should not clear "notification" event handlers', (done) => {
+        const push = PushNotification.init(options);
+        const eventHandler = () => {};
 
         expect(push.handlers.notification.length).toEqual(0);
 
@@ -352,23 +352,23 @@ describe('phonegap-plugin-push', function () {
         expect(push.handlers.notification.length).toEqual(1);
         expect(push.handlers.notification.indexOf(eventHandler)).toBeGreaterThan(-1);
 
-        execSpy.andCallFake(function (win, fail, service, id, args) {
+        execSpy.and.callFake((win, fail, service, id, args) => {
           win();
         });
         push.unregister(
-          function () {
+          () => {
             expect(push.handlers.notification.length).toEqual(1);
             expect(push.handlers.notification.indexOf(eventHandler)).toBeGreaterThan(-1);
             done();
           },
-          function () {},
+          () => {},
           ['foo', 'bar']
         );
       });
 
-      it('should not clear "error" event handlers', function (done) {
-        var push = PushNotification.init(options),
-          eventHandler = function () {};
+      it('should not clear "error" event handlers', (done) => {
+        const push = PushNotification.init(options);
+        const eventHandler = () => {};
 
         expect(push.handlers.error.length).toEqual(0);
 
@@ -377,27 +377,27 @@ describe('phonegap-plugin-push', function () {
         expect(push.handlers.error.length).toEqual(1);
         expect(push.handlers.error.indexOf(eventHandler)).toBeGreaterThan(-1);
 
-        execSpy.andCallFake(function (win, fail, service, id, args) {
+        execSpy.and.callFake((win, fail, service, id, args) => {
           win();
         });
         push.unregister(
-          function () {
+          () => {
             expect(push.handlers.error.length).toEqual(1);
             expect(push.handlers.error.indexOf(eventHandler)).toBeGreaterThan(-1);
             done();
           },
-          function () {},
+          () => {},
           ['foo', 'bar']
         );
       });
     });
 
-    describe('subscribe topic method', function () {
-      describe('cordova.exec', function () {
-        it('should call cordova.exec on next process tick', function (done) {
-          var push = PushNotification.init(options);
-          push.subscribe('foo', function () {}, function () {});
-          setTimeout(function () {
+    describe('subscribe topic method', () => {
+      describe('cordova.exec', () => {
+        it('should call cordova.exec on next process tick', (done) => {
+          const push = PushNotification.init(options);
+          push.subscribe('foo', () => {}, () => {});
+          setTimeout(() => {
             expect(execSpy).toHaveBeenCalledWith(
               jasmine.any(Function),
               jasmine.any(Function),
@@ -411,12 +411,12 @@ describe('phonegap-plugin-push', function () {
       });
     });
 
-    describe('unsubscribe topic method', function () {
-      describe('cordova.exec', function () {
-        it('should call cordova.exec on next process tick', function (done) {
-          var push = PushNotification.init(options);
-          push.unsubscribe('foo', function () {}, function () {});
-          setTimeout(function () {
+    describe('unsubscribe topic method', () => {
+      describe('cordova.exec', () => {
+        it('should call cordova.exec on next process tick', (done) => {
+          const push = PushNotification.init(options);
+          push.unsubscribe('foo', () => {}, () => {});
+          setTimeout(() => {
             expect(execSpy).toHaveBeenCalledWith(
               jasmine.any(Function),
               jasmine.any(Function),
@@ -429,13 +429,13 @@ describe('phonegap-plugin-push', function () {
         });
       });
     });
-    
-    describe('clear notification method', function () {
-      describe('cordova.exec', function () {
-        it('should call cordova.exec on next process tick using number argument', function (done) {
-          var push = PushNotification.init(options);
-          push.clearNotification(function () {}, function () {}, 145);
-          setTimeout(function () {
+
+    describe('clear notification method', () => {
+      describe('cordova.exec', () => {
+        it('should call cordova.exec on next process tick using number argument', (done) => {
+          const push = PushNotification.init(options);
+          push.clearNotification(() => {}, () => {}, 145);
+          setTimeout(() => {
             expect(execSpy).toHaveBeenCalledWith(
               jasmine.any(Function),
               jasmine.any(Function),
@@ -447,10 +447,10 @@ describe('phonegap-plugin-push', function () {
           }, 100);
         });
 
-        it('should call cordova.exec on next process tick using string argument', function (done) {
-          var push = PushNotification.init(options);
-          push.clearNotification(function () {}, function () {}, "145");
-          setTimeout(function () {
+        it('should call cordova.exec on next process tick using string argument', (done) => {
+          const push = PushNotification.init(options);
+          push.clearNotification(() => {}, () => {}, '145');
+          setTimeout(() => {
             expect(execSpy).toHaveBeenCalledWith(
               jasmine.any(Function),
               jasmine.any(Function),

--- a/spec/unit.json
+++ b/spec/unit.json
@@ -1,0 +1,8 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}

--- a/src/js/push.js
+++ b/src/js/push.js
@@ -1,6 +1,3 @@
-/* global cordova:false */
-/* globals window */
-
 /*!
  * Module dependencies.
  */
@@ -30,13 +27,13 @@ class PushNotification {
     this.options = options;
 
     // triggered on registration and notification
-    const success = result => {
+    const success = (result) => {
       if (result && typeof result.registrationId !== 'undefined') {
         this.emit('registration', result);
       } else if (
-        result &&
-        result.additionalData &&
-        typeof result.additionalData.actionCallback !== 'undefined'
+        result
+        && result.additionalData
+        && typeof result.additionalData.actionCallback !== 'undefined'
       ) {
         this.emit(result.additionalData.actionCallback, result);
       } else if (result) {
@@ -45,7 +42,7 @@ class PushNotification {
     };
 
     // triggered on error
-    const fail = msg => {
+    const fail = (msg) => {
       const e = typeof msg === 'string' ? new Error(msg) : msg;
       this.emit('error', e);
     };
@@ -67,7 +64,7 @@ class PushNotification {
 
     if (typeof successCallback !== 'function') {
       console.log(
-        'PushNotification.unregister failure: success callback parameter must be a function'
+        'PushNotification.unregister failure: success callback parameter must be a function',
       );
       return;
     }
@@ -101,7 +98,7 @@ class PushNotification {
 
     if (typeof successCallback !== 'function') {
       console.log(
-        'PushNotification.subscribe failure: success callback parameter must be a function'
+        'PushNotification.subscribe failure: success callback parameter must be a function',
       );
       return;
     }
@@ -124,7 +121,7 @@ class PushNotification {
 
     if (typeof successCallback !== 'function') {
       console.log(
-        'PushNotification.unsubscribe failure: success callback parameter must be a function'
+        'PushNotification.unsubscribe failure: success callback parameter must be a function',
       );
       return;
     }
@@ -138,16 +135,16 @@ class PushNotification {
   setApplicationIconBadgeNumber(successCallback, errorCallback = () => {}, badge) {
     if (typeof errorCallback !== 'function') {
       console.log(
-        'PushNotification.setApplicationIconBadgeNumber failure: failure ' +
-          'parameter not a function'
+        'PushNotification.setApplicationIconBadgeNumber failure: failure '
+          + 'parameter not a function',
       );
       return;
     }
 
     if (typeof successCallback !== 'function') {
       console.log(
-        'PushNotification.setApplicationIconBadgeNumber failure: success ' +
-          'callback parameter must be a function'
+        'PushNotification.setApplicationIconBadgeNumber failure: success '
+          + 'callback parameter must be a function',
       );
       return;
     }
@@ -164,16 +161,16 @@ class PushNotification {
   getApplicationIconBadgeNumber(successCallback, errorCallback = () => {}) {
     if (typeof errorCallback !== 'function') {
       console.log(
-        'PushNotification.getApplicationIconBadgeNumber failure: failure ' +
-          'parameter not a function'
+        'PushNotification.getApplicationIconBadgeNumber failure: failure '
+          + 'parameter not a function',
       );
       return;
     }
 
     if (typeof successCallback !== 'function') {
       console.log(
-        'PushNotification.getApplicationIconBadgeNumber failure: success ' +
-          'callback parameter must be a function'
+        'PushNotification.getApplicationIconBadgeNumber failure: success '
+          + 'callback parameter must be a function',
       );
       return;
     }
@@ -188,15 +185,15 @@ class PushNotification {
   clearAllNotifications(successCallback = () => {}, errorCallback = () => {}) {
     if (typeof errorCallback !== 'function') {
       console.log(
-        'PushNotification.clearAllNotifications failure: failure parameter not a function'
+        'PushNotification.clearAllNotifications failure: failure parameter not a function',
       );
       return;
     }
 
     if (typeof successCallback !== 'function') {
       console.log(
-        'PushNotification.clearAllNotifications failure: success callback ' +
-          'parameter must be a function'
+        'PushNotification.clearAllNotifications failure: success callback '
+          + 'parameter must be a function',
       );
       return;
     }
@@ -212,10 +209,10 @@ class PushNotification {
    */
   clearNotification(successCallback = () => {}, errorCallback = () => {}, id) {
     const idNumber = parseInt(id, 10);
-    if (isNaN(idNumber) || idNumber > Number.MAX_SAFE_INTEGER || idNumber < 0) {
+    if (Number.isNaN(idNumber) || idNumber > Number.MAX_SAFE_INTEGER || idNumber < 0) {
       console.log(
-        'PushNotification.clearNotification failure: id parameter must' +
-          'be a valid integer.'
+        'PushNotification.clearNotification failure: id parameter must'
+          + 'be a valid integer.',
       );
       return;
     }
@@ -238,7 +235,7 @@ class PushNotification {
    */
 
   on(eventName, callback) {
-    if (!this.handlers.hasOwnProperty(eventName)) {
+    if (!Object.prototype.hasOwnProperty.call(this.handlers, eventName)) {
       this.handlers[eventName] = [];
     }
     this.handlers[eventName].push(callback);
@@ -252,7 +249,7 @@ class PushNotification {
    */
 
   off(eventName, handle) {
-    if (this.handlers.hasOwnProperty(eventName)) {
+    if (Object.prototype.hasOwnProperty.call(this.handlers, eventName)) {
       const handleIndex = this.handlers[eventName].indexOf(handle);
       if (handleIndex >= 0) {
         this.handlers[eventName].splice(handleIndex, 1);
@@ -274,14 +271,14 @@ class PushNotification {
   emit(...args) {
     const eventName = args.shift();
 
-    if (!this.handlers.hasOwnProperty(eventName)) {
+    if (!Object.prototype.hasOwnProperty.call(this.handlers, eventName)) {
       return false;
     }
 
-    for (let i = 0, length = this.handlers[eventName].length; i < length; i++) {
+    for (let i = 0, { length } = this.handlers[eventName]; i < length; i += 1) {
       const callback = this.handlers[eventName][i];
       if (typeof callback === 'function') {
-        callback.apply(undefined, args);
+        callback(...args);
       } else {
         console.log(`event handler: ${eventName} must be a function`);
       }
@@ -320,7 +317,7 @@ module.exports = {
    * @return {PushNotification} instance
    */
 
-  init: options => new PushNotification(options),
+  init: (options) => new PushNotification(options),
 
   hasPermission: (successCallback, errorCallback) => {
     exec(successCallback, errorCallback, 'PushNotification', 'hasPermission', []);

--- a/www/push.js
+++ b/www/push.js
@@ -4,22 +4,23 @@
 * DO NOT EDIT IT DIRECTLY
 * 
 * Edit the JS source file src/js/push.js
-**/'use strict';
-
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+**/
+"use strict";
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-/* global cordova:false */
-/* globals window */
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
 /*!
  * Module dependencies.
  */
-
 var exec = cordova.require('cordova/exec');
 
-var PushNotification = function () {
+var PushNotification =
+/*#__PURE__*/
+function () {
   /**
    * PushNotification constructor.
    *
@@ -35,17 +36,15 @@ var PushNotification = function () {
       registration: [],
       notification: [],
       error: []
-    };
+    }; // require options parameter
 
-    // require options parameter
     if (typeof options === 'undefined') {
       throw new Error('The options argument is required.');
-    }
+    } // store the options to this object instance
 
-    // store the options to this object instance
-    this.options = options;
 
-    // triggered on registration and notification
+    this.options = options; // triggered on registration and notification
+
     var success = function success(result) {
       if (result && typeof result.registrationId !== 'undefined') {
         _this.emit('registration', result);
@@ -54,32 +53,32 @@ var PushNotification = function () {
       } else if (result) {
         _this.emit('notification', result);
       }
-    };
+    }; // triggered on error
 
-    // triggered on error
+
     var fail = function fail(msg) {
       var e = typeof msg === 'string' ? new Error(msg) : msg;
-      _this.emit('error', e);
-    };
 
-    // wait at least one process tick to allow event subscriptions
+      _this.emit('error', e);
+    }; // wait at least one process tick to allow event subscriptions
+
+
     setTimeout(function () {
       exec(success, fail, 'PushNotification', 'init', [options]);
     }, 10);
   }
-
   /**
    * Unregister from push notifications
    */
 
 
   _createClass(PushNotification, [{
-    key: 'unregister',
+    key: "unregister",
     value: function unregister(successCallback) {
       var _this2 = this;
 
       var errorCallback = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : function () {};
-      var options = arguments[2];
+      var options = arguments.length > 2 ? arguments[2] : undefined;
 
       if (typeof errorCallback !== 'function') {
         console.log('PushNotification.unregister failure: failure parameter not a function');
@@ -99,12 +98,12 @@ var PushNotification = function () {
             error: []
           };
         }
+
         successCallback();
       };
 
       exec(cleanHandlersAndPassThrough, errorCallback, 'PushNotification', 'unregister', [options]);
     }
-
     /**
      * subscribe to a topic
      * @param   {String}      topic               topic to subscribe
@@ -114,7 +113,7 @@ var PushNotification = function () {
      */
 
   }, {
-    key: 'subscribe',
+    key: "subscribe",
     value: function subscribe(topic, successCallback) {
       var errorCallback = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : function () {};
 
@@ -130,7 +129,6 @@ var PushNotification = function () {
 
       exec(successCallback, errorCallback, 'PushNotification', 'subscribe', [topic]);
     }
-
     /**
      * unsubscribe to a topic
      * @param   {String}      topic               topic to unsubscribe
@@ -140,7 +138,7 @@ var PushNotification = function () {
      */
 
   }, {
-    key: 'unsubscribe',
+    key: "unsubscribe",
     value: function unsubscribe(topic, successCallback) {
       var errorCallback = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : function () {};
 
@@ -156,16 +154,15 @@ var PushNotification = function () {
 
       exec(successCallback, errorCallback, 'PushNotification', 'unsubscribe', [topic]);
     }
-
     /**
      * Call this to set the application icon badge
      */
 
   }, {
-    key: 'setApplicationIconBadgeNumber',
+    key: "setApplicationIconBadgeNumber",
     value: function setApplicationIconBadgeNumber(successCallback) {
       var errorCallback = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : function () {};
-      var badge = arguments[2];
+      var badge = arguments.length > 2 ? arguments[2] : undefined;
 
       if (typeof errorCallback !== 'function') {
         console.log('PushNotification.setApplicationIconBadgeNumber failure: failure ' + 'parameter not a function');
@@ -177,15 +174,16 @@ var PushNotification = function () {
         return;
       }
 
-      exec(successCallback, errorCallback, 'PushNotification', 'setApplicationIconBadgeNumber', [{ badge: badge }]);
+      exec(successCallback, errorCallback, 'PushNotification', 'setApplicationIconBadgeNumber', [{
+        badge: badge
+      }]);
     }
-
     /**
      * Get the application icon badge
      */
 
   }, {
-    key: 'getApplicationIconBadgeNumber',
+    key: "getApplicationIconBadgeNumber",
     value: function getApplicationIconBadgeNumber(successCallback) {
       var errorCallback = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : function () {};
 
@@ -201,13 +199,12 @@ var PushNotification = function () {
 
       exec(successCallback, errorCallback, 'PushNotification', 'getApplicationIconBadgeNumber', []);
     }
-
     /**
      * Clear all notifications
      */
 
   }, {
-    key: 'clearAllNotifications',
+    key: "clearAllNotifications",
     value: function clearAllNotifications() {
       var successCallback = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : function () {};
       var errorCallback = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : function () {};
@@ -224,7 +221,6 @@ var PushNotification = function () {
 
       exec(successCallback, errorCallback, 'PushNotification', 'clearAllNotifications', []);
     }
-
     /**
      * Clears notifications that have the ID specified.
      * @param  {Function} [successCallback] Callback function to be called on success.
@@ -233,21 +229,20 @@ var PushNotification = function () {
      */
 
   }, {
-    key: 'clearNotification',
+    key: "clearNotification",
     value: function clearNotification() {
       var successCallback = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : function () {};
       var errorCallback = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : function () {};
-      var id = arguments[2];
-
+      var id = arguments.length > 2 ? arguments[2] : undefined;
       var idNumber = parseInt(id, 10);
-      if (isNaN(idNumber) || idNumber > Number.MAX_SAFE_INTEGER || idNumber < 0) {
+
+      if (Number.isNaN(idNumber) || idNumber > Number.MAX_SAFE_INTEGER || idNumber < 0) {
         console.log('PushNotification.clearNotification failure: id parameter must' + 'be a valid integer.');
         return;
       }
 
       exec(successCallback, errorCallback, 'PushNotification', 'clearNotification', [idNumber]);
     }
-
     /**
      * Listen for an event.
      *
@@ -262,14 +257,14 @@ var PushNotification = function () {
      */
 
   }, {
-    key: 'on',
+    key: "on",
     value: function on(eventName, callback) {
-      if (!this.handlers.hasOwnProperty(eventName)) {
+      if (!Object.prototype.hasOwnProperty.call(this.handlers, eventName)) {
         this.handlers[eventName] = [];
       }
+
       this.handlers[eventName].push(callback);
     }
-
     /**
      * Remove event listener.
      *
@@ -278,16 +273,16 @@ var PushNotification = function () {
      */
 
   }, {
-    key: 'off',
+    key: "off",
     value: function off(eventName, handle) {
-      if (this.handlers.hasOwnProperty(eventName)) {
+      if (Object.prototype.hasOwnProperty.call(this.handlers, eventName)) {
         var handleIndex = this.handlers[eventName].indexOf(handle);
+
         if (handleIndex >= 0) {
           this.handlers[eventName].splice(handleIndex, 1);
         }
       }
     }
-
     /**
      * Emit an event.
      *
@@ -300,31 +295,32 @@ var PushNotification = function () {
      */
 
   }, {
-    key: 'emit',
+    key: "emit",
     value: function emit() {
-      for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+      for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
         args[_key] = arguments[_key];
       }
 
       var eventName = args.shift();
 
-      if (!this.handlers.hasOwnProperty(eventName)) {
+      if (!Object.prototype.hasOwnProperty.call(this.handlers, eventName)) {
         return false;
       }
 
-      for (var i = 0, length = this.handlers[eventName].length; i < length; i++) {
+      for (var i = 0, length = this.handlers[eventName].length; i < length; i += 1) {
         var callback = this.handlers[eventName][i];
+
         if (typeof callback === 'function') {
-          callback.apply(undefined, args);
+          callback.apply(void 0, args);
         } else {
-          console.log('event handler: ' + eventName + ' must be a function');
+          console.log("event handler: ".concat(eventName, " must be a function"));
         }
       }
 
       return true;
     }
   }, {
-    key: 'finish',
+    key: "finish",
     value: function finish() {
       var successCallback = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : function () {};
       var errorCallback = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : function () {};
@@ -346,10 +342,10 @@ var PushNotification = function () {
 
   return PushNotification;
 }();
-
 /*!
  * Push Notification Plugin.
  */
+
 
 module.exports = {
   /**
@@ -361,23 +357,18 @@ module.exports = {
    * @param {Object} options
    * @return {PushNotification} instance
    */
-
   init: function init(options) {
     return new PushNotification(options);
   },
-
   hasPermission: function hasPermission(successCallback, errorCallback) {
     exec(successCallback, errorCallback, 'PushNotification', 'hasPermission', []);
   },
-
   createChannel: function createChannel(successCallback, errorCallback, channel) {
     exec(successCallback, errorCallback, 'PushNotification', 'createChannel', [channel]);
   },
-
   deleteChannel: function deleteChannel(successCallback, errorCallback, channelId) {
     exec(successCallback, errorCallback, 'PushNotification', 'deleteChannel', [channelId]);
   },
-
   listChannels: function listChannels(successCallback, errorCallback) {
     exec(successCallback, errorCallback, 'PushNotification', 'listChannels', []);
   },


### PR DESCRIPTION
## Description

* Update ESLint related dev dependencies
* Improve ESLint configurations
* Replace "eslint-config-airbnb" with "eslint-config-airbnb-base"
* Drop "eslint-plugin-jsx-a11y"
* Drop "eslint-plugin-react"
* Fixed linting errors
* Replace "jasmine-node" with "jasmine"
* Update babel related dev dependencies
* Move "babel-plugin-add-header-comment" to "devDependencies"
* Update nodemon
* Update node package scripts

## Related Issue

This PR is neither bug fix or feature request implementation. 
As this is a general chore task, there is no related issue. If an issue is necessary I will create on request.

## Motivation and Context

* Use updated dependencies
* Removes audit warnings

```
                       === npm audit security report ===                        
                                                                                
found 0 vulnerabilities
 in 6569 scanned packages
```

* Removes unnecessary/unused packages

```
- eslint-plugin-jsx-a11y
- eslint-plugin-react
```

## How Has This Been Tested?

* `npm t`

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

A dev related dependency was set as a non-dev dependency. This would imply that it was used in production. As this PR moved that dependency to `devDependencies`, it would be seen as major change. Since this dependency should not have been used anywhere in the production code, there should be no affect, but to be safe, I flagged this as major/breaking change.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
