### PR TITLE
enable automatic permission request by user for notifications when ch…

### DIFF
--- a/src/ios/AppDelegate+notification.h
+++ b/src/ios/AppDelegate+notification.h
@@ -17,6 +17,7 @@ extern NSString *const pushPluginApplicationDidBecomeActiveNotification;
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:( void (^)(UIBackgroundFetchResult))completionHandler;
 - (void)pushPluginOnApplicationDidBecomeActive:(UIApplication *)application;
 - (void)checkUserHasRemoteNotificationsEnabledWithCompletionHandler:(nonnull void (^)(BOOL))completionHandler;
+- (void)requestUserPermissionRemoteNotificationsWithCompletionHandler:(nonnull void (^)(BOOL))completionHandler;
 - (id) getCommandInstance:(NSString*)className;
 
 @property (nonatomic, retain) NSDictionary  *launchNotification;

--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -151,6 +151,14 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
     }];
 }
 
+- (void)requestUserPermissionRemoteNotificationsWithCompletionHandler:(nonnull void (^)(BOOL))completionHandler
+{
+    UNAuthorizationOptions options = (UNAuthorizationOptionBadge | UNAuthorizationOptionSound | UNAuthorizationOptionAlert);
+     [[UNUserNotificationCenter currentNotificationCenter] requestAuthorizationWithOptions:options completionHandler:^(BOOL granted, NSError* e) {
+         completionHandler(granted);
+     }];
+}
+
 - (void)pushPluginOnApplicationDidBecomeActive:(NSNotification *)notification {
 
     NSLog(@"active");

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -544,10 +544,19 @@
     id<UIApplicationDelegate> appDelegate = [UIApplication sharedApplication].delegate;
     if ([appDelegate respondsToSelector:@selector(checkUserHasRemoteNotificationsEnabledWithCompletionHandler:)]) {
         [appDelegate performSelector:@selector(checkUserHasRemoteNotificationsEnabledWithCompletionHandler:) withObject:^(BOOL isEnabled) {
-            NSMutableDictionary* message = [NSMutableDictionary dictionaryWithCapacity:1];
-            [message setObject:[NSNumber numberWithBool:isEnabled] forKey:@"isEnabled"];
-            CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:message];
-            [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
+            if(!isEnabled){
+                [appDelegate performSelector:@selector(requestUserPermissionRemoteNotificationsWithCompletionHandler:) withObject:^(BOOL granted) {
+                        NSMutableDictionary* message = [NSMutableDictionary dictionaryWithCapacity:1];
+                        [message setObject:[NSNumber numberWithBool:granted] forKey:@"isEnabled"];
+                        CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:message];
+                        [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
+                 }];
+            }else{
+                NSMutableDictionary* message = [NSMutableDictionary dictionaryWithCapacity:1];
+                [message setObject:[NSNumber numberWithBool:isEnabled] forKey:@"isEnabled"];
+                CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:message];
+                [self.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
+            }
         }];
     }
 }


### PR DESCRIPTION
enable automatic permission request by user for notifications when checkpermission called

## Description
First we have to request notification permission from user. Without this you cannot send notifications. 

I had to use localnotifications plugin to request permissions but because of that the push.on('registration',) did not fired on ios when app in foreground.
issue: https://github.com/phonegap/phonegap-plugin-push/issues/2222

This is a solution for this:
https://github.com/phonegap/phonegap-plugin-push/issues/2085

## Related Issue
https://github.com/phonegap/phonegap-plugin-push/issues/2085

## Motivation and Context
I had to use localnotifications plugin to request permissions but because of that the push.on('registration',) did not fired on ios when app in foreground.

## How Has This Been Tested?

## Screenshots (if appropriate):
https://i1.wp.com/www.simplifiedios.net/wp-content/uploads/2018/01/iOS-Local-Notification-Authorization.png?w=399&ssl=1

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
