### PR TITLE
:sparkles: :penguin: Allow implementation of a user invitation to fix settings

### DIFF
--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -93,6 +93,7 @@ public interface PushConstants {
   public static final String CHANNEL_ID = "id";
   public static final String CHANNEL_DESCRIPTION = "description";
   public static final String CHANNEL_IMPORTANCE = "importance";
+  public static final String CHANNEL_SOUND_URI = "soundUri";
   public static final String CHANNEL_LIGHT_COLOR = "lightColor";
   public static final String CHANNEL_VIBRATION = "vibration";
   public static final String ANDROID_CHANNEL_ID = "android_channel_id";
@@ -102,4 +103,5 @@ public interface PushConstants {
   public static final String ONGOING = "ongoing";
   public static final String LIST_CHANNELS = "listChannels";
   public static final String CLEAR_NOTIFICATION = "clearNotification";
+  public static final String OPEN_NOTIFICATIONS_SETTINGS = "openNotificationsSettings";
 }

--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -6,12 +6,14 @@ import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.ContentResolver;
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.media.AudioAttributes;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
 import android.util.Log;
@@ -69,6 +71,8 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
         JSONObject channel = new JSONObject();
         channel.put(CHANNEL_ID, notificationChannel.getId());
         channel.put(CHANNEL_DESCRIPTION, notificationChannel.getDescription());
+        channel.put(CHANNEL_IMPORTANCE, notificationChannel.getImportance());
+        channel.put(CHANNEL_SOUND_URI, notificationChannel.getSound());
         channels.put(channel);
       }
     }
@@ -429,6 +433,21 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
             Log.v(LOG_TAG, "clearNotification");
             int id = data.getInt(0);
             clearNotification(id);
+            callbackContext.success();
+          } catch (JSONException e) {
+            callbackContext.error(e.getMessage());
+          }
+        }
+      });
+    } else if (OPEN_NOTIFICATIONS_SETTINGS.equals(action)) {
+      // open notifications settings
+      cordova.getThreadPool().execute(new Runnable() {
+        public void run() {
+          try {
+            Intent intent = new Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS);
+            intent.putExtra(Settings.EXTRA_APP_PACKAGE, cordova.getContext().getApplicationInfo().packageName);
+            intent.putExtra(Settings.EXTRA_CHANNEL_ID, data.getString(0));
+            cordova.getActivity().getApplicationContext().startActivity(intent);
             callbackContext.success();
           } catch (JSONException e) {
             callbackContext.error(e.getMessage());

--- a/src/js/push.js
+++ b/src/js/push.js
@@ -335,6 +335,10 @@ module.exports = {
     exec(successCallback, errorCallback, 'PushNotification', 'listChannels', []);
   },
 
+  openNotificationsSettings: (successCallback, errorCallback, channelId) => {
+    exec(successCallback, errorCallback, 'PushNotification', 'openNotificationsSettings', [channelId]);
+  },
+
   /**
    * PushNotification Object.
    *

--- a/www/push.js
+++ b/www/push.js
@@ -372,6 +372,9 @@ module.exports = {
   listChannels: function listChannels(successCallback, errorCallback) {
     exec(successCallback, errorCallback, 'PushNotification', 'listChannels', []);
   },
+  openNotificationsSettings: function openNotificationsSettings(successCallback, errorCallback, channelId) {
+    exec(successCallback, errorCallback, 'PushNotification', 'openNotificationsSettings', [channelId]);
+  },
 
   /**
    * PushNotification Object.


### PR DESCRIPTION
## Description
Added OPEN_NOTIFICATIONS_SETTINGS intent trigger method along with Importance and SoundUri values to allow implementation of a user invitation to fix settings:
https://developer.android.com/training/notify-user/channels#UpdateChannel

## Related Issue
#2847

## Motivation and Context
In our own project, we need to be able to open Intent related to Channel settings.
Please see https://developer.android.com/training/notify-user/channels#UpdateChannel
for more details over this need.

## How Has This Been Tested?
Tested in our project, not sure how we should proceed for testing. Could be Spy call checks like existing methods, however I have noticed some methods are untested. Due to it's Android only nature.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All -new and- existing tests passed.
