### PR TITLE
support inline reply in ios pushnotification

### DIFF
--- a/src/ios/PushPlugin.h
+++ b/src/ios/PushPlugin.h
@@ -41,7 +41,7 @@
 
     NSMutableDictionary *handlerObj;
     void (^completionHandler)(UIBackgroundFetchResult);
-
+    NSString *replyCallBack;
     BOOL ready;
 }
 

--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -241,19 +241,37 @@
                     id category = [categoryOptions objectForKey:key];
 
                     id yesButton = [category objectForKey:@"yes"];
+                   
                     UNNotificationAction *yesAction;
                     if (yesButton != nil && [yesButton  isKindOfClass:[NSDictionary class]]) {
-                        yesAction = [self createAction: yesButton];
+                         id isInline = [yesButton objectForKey:@"inline"];
+                         if (isInline != nil && (([isInline isKindOfClass:[NSString class]] && [isInline isEqualToString:@"true"]) || [isInline boolValue])) {
+                            yesAction = [self createReplyAction: yesButton];
+                        }else{
+                            yesAction = [self createAction: yesButton];
+                        }
                     }
                     id noButton = [category objectForKey:@"no"];
+                   
                     UNNotificationAction *noAction;
                     if (noButton != nil && [noButton  isKindOfClass:[NSDictionary class]]) {
-                        noAction = [self createAction: noButton];
+                        id isInline = [noButton objectForKey:@"inline"];
+                        if (isInline != nil && (([isInline isKindOfClass:[NSString class]] && [isInline isEqualToString:@"true"]) || [isInline boolValue])) {
+                            noAction = [self createReplyAction: noButton];
+                        }else{
+                            noAction = [self createAction: noButton];
+                        }
                     }
                     id maybeButton = [category objectForKey:@"maybe"];
+                   
                     UNNotificationAction *maybeAction;
                     if (maybeButton != nil && [maybeButton  isKindOfClass:[NSDictionary class]]) {
-                        maybeAction = [self createAction: maybeButton];
+                        id  isInline = [maybeButton objectForKey:@"inline"];
+                        if (isInline != nil && (([isInline isKindOfClass:[NSString class]] && [isInline isEqualToString:@"true"]) || [isInline boolValue])) {
+                            maybeAction = [self createReplyAction: maybeButton];
+                        }else{
+                            maybeAction = [self createAction: maybeButton];
+                        }
                     }
 
                     // Identifier to include in your push payload and local notification
@@ -282,6 +300,9 @@
             }
 
             UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+            
+            [center setDelegate:self];
+            
             [center setNotificationCategories:categories];
             [self handleNotificationSettingsWithAuthorizationOptions:[NSNumber numberWithInteger:authorizationOptions]];
 
@@ -353,6 +374,15 @@
     }
 
     return [UNNotificationAction actionWithIdentifier:identifier title:title options:options];
+}
+
+- (UNTextInputNotificationAction *)createReplyAction:(NSDictionary *)dictionary {
+    replyCallBack = [dictionary objectForKey:@"callback"];
+    UNNotificationActionOptions effectiveMode = UNNotificationActionOptionNone;
+    
+    UNTextInputNotificationAction *myAction = [UNTextInputNotificationAction actionWithIdentifier:[dictionary objectForKey:@"callback"] title:[dictionary objectForKey:@"title"] options:effectiveMode];
+    
+    return myAction;
 }
 
 - (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
@@ -486,6 +516,22 @@
         self.coldstart = NO;
         self.notificationMessage = nil;
     }
+}
+
+-(void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler {
+    
+    NSLog(@"didReceiveNotificationResponse %@",response);
+    NSLog(@"response.actionIdentifier %@",response.actionIdentifier);
+    NSLog(@"replyCallBack %@", replyCallBack);
+    
+    //for inline reply notification
+    if ([response isKindOfClass:[UNTextInputNotificationResponse class]]) {
+        [[NSNotificationCenter defaultCenter] postNotificationName:@"inlinecallback" object:nil userInfo:response];
+    }else { // for confirm and decline notification
+        [[NSNotificationCenter defaultCenter] postNotificationName:@"confirmcallback" object:nil userInfo:response];
+    }
+    
+    completionHandler();
 }
 
 - (void)clearNotification:(CDVInvokedUrlCommand *)command


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This code is for handling inline reply in push notification specifically in iOS platform.

## Description
<!--- Describe your changes in detail -->

We have implemented inline reply button for push notification. When ins category configuration we add a property inline which is type of boolean, when developer configure it as true, then when he/she send push notification using that category device received that notification with inline reply action Botton. When User press that button it will open text box where user will give reply. We have handle that reply in code and user will get userText as property in additional data object in callback.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
https://github.com/phonegap/phonegap-plugin-push/issues/2823
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required to support inline reply in iOS platform. So developer can use it with this plugin and do not need to waste time on other study.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
We have do 1 round of QA team.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![IMG_0115](https://user-images.githubusercontent.com/57472966/68454713-83669000-021f-11ea-8fc1-1d6246b44311.PNG)
![Pasted Image- Nov 8, 2019 - 11-49-41am](https://user-images.githubusercontent.com/57472966/68454721-895c7100-021f-11ea-939f-422ffdac3d22.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
