### PR TITLE
Update PushNotificationStatic type definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -314,9 +314,69 @@ declare namespace PhonegapPluginPush {
 		notId?: string
 	}
 
+	interface Channel {
+		/**
+		 * The id of the channel. Must be unique per package. The value may be truncated if it is too long.
+		 */
+		id: string;
+		/**
+		 * The user visible name of the channel. The recommended maximum length is 40 characters; the value may be truncated if it is too long.
+		 */
+		description: string;
+		/**
+		 * The importance of the channel. This controls how interruptive notifications posted to this channel are. The importance property goes from 1 = Lowest, 2 = Low, 3 = Normal, 4 = High and 5 = Highest.
+		 */
+		importance: number;
+		/**
+		 * The name of the sound file to be played upon receipt of the notification in this channel. Empty string to disable sound. Cannot be changed after channel is created.
+		 */
+		sound?: string;
+		/**
+		 * Boolean sets whether notification posted to this channel should vibrate. Array sets custom vibration pattern. Example - vibration: [2000, 1000, 500, 500]. Cannot be changed after channel is created.
+		 */
+		vibration?: boolean|number[];
+		/**
+		 * Sets whether notifications posted to this channel appear on the lockscreen or not, and if so, whether they appear in a redacted form. 0 = Private, 1 = Public, -1 = Secret.
+		 */
+		visibility?: number;
+	}
+
 	interface PushNotificationStatic {
-		init(options: InitOptions): PushNotification
 		new (options: InitOptions): PushNotification
+		/**
+		 * Initializes the plugin on the native side.
+		 * @param options An object describing relevant specific options for all target platforms.
+		 */
+		init(options: InitOptions): PushNotification
+		/**
+		 * Checks whether the push notification permission has been granted.
+		 * @param successCallback Is called when the api successfully retrieves the details on the permission.
+		 * @param errorCallback	Is called when the api fails to retrieve the details on the permission.
+		 */
+		hasPermission(successCallback: (data: {isEnabled: boolean}) => void, errorCallback: () => void): void;
+		/**
+		 * Android only
+		 * Create a new notification channel for Android O and above.
+		 * @param successCallback Is called when the api successfully creates a channel.
+		 * @param errorCallback Is called when the api fails to create a channel.
+		 * @param channel The options for the channel.
+		 */
+		createChannel(successCallback: () => void, errorCallback: () => void, channel: Channel): void;
+		/**
+		 * Android only
+		 * Delete a notification channel for Android O and above.
+		 * @param successCallback Is called when the api successfully deletes a channel.
+		 * @param errorCallback Is called when the api fails to create a channel.
+		 * @param channelId The ID of the channel.
+		 */
+		deleteChannel(successCallback: () => void, errorCallback: () => void, channelId: string): void;
+		/**
+		 * Android only
+		 * Returns a list of currently configured channels.
+		 * @param successCallback Is called when the api successfully retrieves the list of channels.
+		 * @param errorCallback Is called when the api fails to retrieve the list of channels.
+		 */
+		listChannels(successCallback: (channels: Channel[]) => void, errorCallback: () => void): void;
 	}
 }
 


### PR DESCRIPTION
##  Description

Add some missing functions to the PushNotificationStatic type in the TypeScript type definitions, based on the JS implementation and the API documentation.

## Related Issue

Fixes #2891

## Motivation and Context

This allows me to use the `hasPermission` function from my TypeScript project without it complaining about it not being on the PushNotification type. And as I was adding that one, I decided to add the others for completeness.

## How Has This Been Tested?

I manually copied the `index.d.ts` into my projects `node_modules` to verify the changes.

## Screenshots (if appropriate):

n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
