### PR TITLE
Move clearAllNotifications from pause to destroy

### DIFF
--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -510,12 +510,6 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
   public void onPause(boolean multitasking) {
     super.onPause(multitasking);
     gForeground = false;
-
-    SharedPreferences prefs = getApplicationContext().getSharedPreferences(COM_ADOBE_PHONEGAP_PUSH,
-        Context.MODE_PRIVATE);
-    if (prefs.getBoolean(CLEAR_NOTIFICATIONS, true)) {
-      clearAllNotifications();
-    }
   }
 
   @Override
@@ -529,6 +523,12 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
     super.onDestroy();
     gForeground = false;
     gWebView = null;
+    
+    SharedPreferences prefs = getApplicationContext().getSharedPreferences(COM_ADOBE_PHONEGAP_PUSH,
+        Context.MODE_PRIVATE);
+    if (prefs.getBoolean(CLEAR_NOTIFICATIONS, true)) {
+      clearAllNotifications();
+    }
   }
 
   private void clearAllNotifications() {


### PR DESCRIPTION
Notifications should persist when the app is moved to the background in order to draw the user back to re-activate the app when they are done multitasking.

Notifications should be destroyed when the app is closed though to avoid clutter.

This should also resolve:
https://github.com/ghenry22/cordova-plugin-music-controls2/issues/7

## Description
move the the clear all notifications call into onDestroy instead of onPause.

## Related Issue
https://github.com/phonegap/phonegap-plugin-push/issues/2772
https://github.com/ghenry22/cordova-plugin-music-controls2/issues/7

## Motivation and Context
App notifications are still valid while the app is in the background, so it doesn't make sense to destroy all notifications as soon as the app is backgrounded.  A lot of notifications are specifically to lead people to bring the app back to the foreground.

Also as this plugin clears ALL notifications from the app, even those generated by other plugins, it causes issues where other plugins need a persistent notification while in background (ie for music playback or voip).

## How Has This Been Tested?
Tested in my own app and in a users app (as per the music-controls2 issue report)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
