### PR TITLE
Localization with FCM Admin (Node.js)

### DIFF
--- a/docs/PAYLOAD.md
+++ b/docs/PAYLOAD.md
@@ -302,6 +302,21 @@ Or use localization with formatted constants.
 }
 ```
 
+Or use localization compatible with FCM Admin package for Node.js (Android only)
+```json
+{
+  "android": {
+    "data": {
+      "title_loc_key": "NOTIFICATION_TITLE",
+      "body_loc_key": "NOTIFICATION_MESSAGE",
+      "body_loc_args": "[\"data\"]", // args as stringified array
+      "title_loc_args": "[\"data\"]"
+    }
+  },
+  "tokens": ["REGISTRARION_ID_1", "REGISTRATION_ID_2", ...]
+}
+```
+
 Here is an example using fcm-node that sends the above JSON:
 
 ```javascript

--- a/docs/PAYLOAD.md
+++ b/docs/PAYLOAD.md
@@ -309,11 +309,11 @@ Or use localization compatible with FCM Admin package for Node.js (Android only)
     "data": {
       "title_loc_key": "NOTIFICATION_TITLE",
       "body_loc_key": "NOTIFICATION_MESSAGE",
-      "body_loc_args": "[\"data\"]", // args as stringified array
-      "title_loc_args": "[\"data\"]"
+      "body_loc_args": "[\"args\", \"as\", \"stringified\", \"array\"]",
+      "title_loc_args": "[\"args\", \"as\", \"stringified\", \"array\"]"
     }
   },
-  "tokens": ["REGISTRARION_ID_1", "REGISTRATION_ID_2", ...]
+  "tokens": ["REGISTRARION_ID_1", "REGISTRATION_ID_2"]
 }
 ```
 

--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -68,6 +68,10 @@ public interface PushConstants {
   public static final String INLINE_REPLY_LABEL = "replyLabel";
   public static final String LOC_KEY = "locKey";
   public static final String LOC_DATA = "locData";
+  public static final String TITLE_LOC_KEY = "title_loc_key";
+  public static final String TITLE_LOC_DATA = "title_loc_args";
+  public static final String BODY_LOC_KEY = "body_loc_key";
+  public static final String BODY_LOC_DATA = "body_loc_args";
   public static final String TWILIO_BODY = "twi_body";
   public static final String TWILIO_TITLE = "twi_title";
   public static final String TWILIO_SOUND = "twi_sound";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Use params allowed for localization by FCM Admin module for Node.js. This pull requests is for Android only, I can't develop it for iOS currently.
## Description
<!--- Describe your changes in detail -->
Modified localizeKey and nomalizeExtras (FCMService.java) to correctly handle localization params allowed by official FCM Admin package. Added new constants (PushConstants.java)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2435 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`fcm-node` package is depracated and this plugin needs client side message localization capability.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Sending requests to FCM as shown in example in docs.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
