### PR TITLE
iOS Foreground Notification Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "phonegap-plugin-push",
   "description": "Register and receive push notifications.",
   "types": "./types/index.d.ts",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "homepage": "http://github.com/phonegap/phonegap-plugin-push#readme",
   "repository": {
     "type": "git",

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
   xmlns:android="http://schemas.android.com/apk/res/android" 
   xmlns:amazon="http://schemas.android.com/apk/lib/com.amazon.device.ads" 
   xmlns:rim="http://www.blackberry.com/ns/widgets" 
-  id="phonegap-plugin-push" version="2.3.0">
+  id="phonegap-plugin-push" version="2.3.1">
   <name>PushPlugin</name>
   <description>    This plugin allows your application to receive push notifications on Android, iOS and Windows devices.    Android uses Firebase Cloud Messaging.    iOS uses Apple APNS Notifications.    Windows uses Microsoft WNS Notifications.  </description>
   <license>MIT</license>

--- a/src/ios/AppDelegate+notification.m
+++ b/src/ios/AppDelegate+notification.m
@@ -197,7 +197,7 @@ NSString *const pushPluginApplicationDidBecomeActiveNotification = @"pushPluginA
     pushHandler.isInline = YES;
     [pushHandler notificationReceived];
 
-    completionHandler(UNNotificationPresentationOptionNone);
+    completionHandler(UNNotificationPresentationOptionAlert);
 }
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center


### PR DESCRIPTION
## Description
iOS Notifications didn't appear on Foreground

## Related Issue
https://github.com/phonegap/phonegap-plugin-push/issues/2783

## How Has This Been Tested?
On iPhone 8+, iOS 13.5.1

## Screenshots (if appropriate):

## Types of changes
A simple NotificationPresentationOption was required while handling in Foreground.